### PR TITLE
🔒 Fix Arbitrary File Deletion via Misconfigured REPORT_DIR

### DIFF
--- a/deep_research_project/chainlit_app.py
+++ b/deep_research_project/chainlit_app.py
@@ -26,6 +26,18 @@ def cleanup_old_reports(report_dir: pathlib.Path, cleanup_age: int):
     if not report_dir.exists():
         return
     
+    # Safety check: ensure report_dir is within the project root and is not the root itself
+    try:
+        project_root = pathlib.Path(__file__).parent.parent.resolve()
+        resolved_report_dir = report_dir.resolve()
+
+        if not resolved_report_dir.is_relative_to(project_root) or resolved_report_dir == project_root:
+            logger.warning(f"Cleanup skipped: {report_dir} is not a valid subdirectory of {project_root}")
+            return
+    except Exception as e:
+        logger.error(f"Error validating report directory: {e}")
+        return
+
     now = time.time()
     count = 0
     try:

--- a/deep_research_project/config/config.py
+++ b/deep_research_project/config/config.py
@@ -80,7 +80,18 @@ class Configuration:
         self.RESEARCH_PLAN_MIN_SECTIONS: int = int(os.getenv("RESEARCH_PLAN_MIN_SECTIONS", 3))
         self.RESEARCH_PLAN_MAX_SECTIONS: int = int(os.getenv("RESEARCH_PLAN_MAX_SECTIONS", 5))
         self.MAX_QUERY_WORDS: int = int(os.getenv("MAX_QUERY_WORDS", 12))
-        self.REPORT_DIR: str = os.getenv("REPORT_DIR", "temp_reports")
+
+        # Security: Validate REPORT_DIR to prevent arbitrary file deletion
+        raw_report_dir = os.getenv("REPORT_DIR", "temp_reports")
+        # For simplicity and security, we ensure it's treated as a relative path
+        # from the project root if it looks suspicious or is absolute.
+        if os.path.isabs(raw_report_dir) or ".." in raw_report_dir:
+            self.REPORT_DIR: str = os.path.basename(raw_report_dir)
+            if not self.REPORT_DIR: # in case it was just "/"
+                self.REPORT_DIR = "temp_reports"
+        else:
+            self.REPORT_DIR: str = raw_report_dir
+
         self.CLEANUP_AGE_SECONDS: int = int(os.getenv("CLEANUP_AGE_SECONDS", 3600))
         self.DEFAULT_LANGUAGE: str = os.getenv("DEFAULT_LANGUAGE", "Japanese")
 


### PR DESCRIPTION
This pull request addresses a security vulnerability where misconfiguration of `REPORT_DIR` could lead to arbitrary file deletion during the cleanup process.

### 🎯 What
The `cleanup_old_reports` function in `chainlit_app.py` was previously iterating over any directory provided in the configuration without validation.

### ⚠️ Risk
An attacker who can control the `REPORT_DIR` environment variable could cause the application to delete critical system files or application data (e.g., setting `REPORT_DIR=/etc` or `REPORT_DIR=/`).

### 🛡️ Solution
1. **Defense in Depth**:
   - **Configuration Level**: `Configuration` now sanitizes `REPORT_DIR` by ensuring it's treated as a relative path (using `os.path.basename`) if it's absolute or contains traversal markers.
   - **Runtime Level**: `cleanup_old_reports` now performs a strict check using `pathlib` to ensure the resolved target directory is indeed a subdirectory of the project root and is not the project root itself.
2. **Robustness**: The fix handles symlinks correctly by using `.resolve()` before validation.


---
*PR created automatically by Jules for task [2589793839780868337](https://jules.google.com/task/2589793839780868337) started by @chottokun*