### PR TITLE
🧹 Replace Deprecated asyncio.get_event_loop()

### DIFF
--- a/deep_research_project/tests/test_llm_client_rate_limit.py
+++ b/deep_research_project/tests/test_llm_client_rate_limit.py
@@ -23,14 +23,15 @@ class TestLLMClientRateLimit(unittest.IsolatedAsyncioTestCase):
             client.llm = AsyncMock()
             client.llm.ainvoke.return_value = MagicMock(content="response")
 
-            start_time = asyncio.get_event_loop().time()
+            loop = asyncio.get_running_loop()
+            start_time = loop.time()
             # Send 3 requests
             await asyncio.gather(
                 client.generate_text("p1"),
                 client.generate_text("p2"),
                 client.generate_text("p3")
             )
-            end_time = asyncio.get_event_loop().time()
+            end_time = loop.time()
 
             duration = end_time - start_time
             # Request 1: 0s
@@ -47,13 +48,14 @@ class TestLLMClientRateLimit(unittest.IsolatedAsyncioTestCase):
             client.llm = AsyncMock()
             client.llm.ainvoke.return_value = MagicMock(content="response")
 
-            start_time = asyncio.get_event_loop().time()
+            loop = asyncio.get_running_loop()
+            start_time = loop.time()
             await asyncio.gather(
                 client.generate_text("p1"),
                 client.generate_text("p2"),
                 client.generate_text("p3")
             )
-            end_time = asyncio.get_event_loop().time()
+            end_time = loop.time()
 
             duration = end_time - start_time
             # Should be almost instantaneous

--- a/deep_research_project/tests/test_research_loop_parallel.py
+++ b/deep_research_project/tests/test_research_loop_parallel.py
@@ -43,9 +43,10 @@ class TestResearchLoopParallel(unittest.IsolatedAsyncioTestCase):
 
         self.loop.llm_client.generate_text = AsyncMock(side_effect=mock_generate_text)
 
-        start_time = asyncio.get_event_loop().time()
+        loop = asyncio.get_running_loop()
+        start_time = loop.time()
         await self.loop._summarize_sources(selected)
-        end_time = asyncio.get_event_loop().time()
+        end_time = loop.time()
 
         duration = end_time - start_time
         # 2 chunks -> 1 wave of 2 if parallel -> 0.5s
@@ -58,9 +59,10 @@ class TestResearchLoopParallel(unittest.IsolatedAsyncioTestCase):
         selected = [
             SearchResult(title="T1", link="L1", snippet="1234567890123456789012345678901234567890") # 4 chunks
         ]
-        start_time = asyncio.get_event_loop().time()
+        loop = asyncio.get_running_loop()
+        start_time = loop.time()
         await self.loop._summarize_sources(selected)
-        end_time = asyncio.get_event_loop().time()
+        end_time = loop.time()
 
         duration = end_time - start_time
         # 4 chunks, concurrency 2 -> 2 waves of 0.5s -> ~1.0s
@@ -81,13 +83,14 @@ class TestResearchLoopParallel(unittest.IsolatedAsyncioTestCase):
         self.loop.llm_client.generate_structured = AsyncMock(side_effect=mock_gen_struct)
         self.loop.llm_client.generate_text = AsyncMock(side_effect=mock_gen_text)
 
-        start_time = asyncio.get_event_loop().time()
+        loop = asyncio.get_running_loop()
+        start_time = loop.time()
         # These two should run in parallel
         await asyncio.gather(
             self.loop._extract_entities_and_relations(),
             self.loop._reflect_on_summary()
         )
-        end_time = asyncio.get_event_loop().time()
+        end_time = loop.time()
 
         duration = end_time - start_time
         # If parallel, ~0.5s. If sequential, ~1.0s.

--- a/deep_research_project/tools/llm_client.py
+++ b/deep_research_project/tools/llm_client.py
@@ -87,11 +87,12 @@ class LLMClient:
         limit_interval = 60.0 / self.config.LLM_RATE_LIMIT_RPM if self.config.LLM_RATE_LIMIT_RPM > 0 else 0
 
         async with self._rate_limit_lock:
-            current_time = asyncio.get_event_loop().time()
+            loop = asyncio.get_running_loop()
+            current_time = loop.time()
             time_since_last = current_time - self._last_request_time
             if time_since_last < limit_interval:
                 await asyncio.sleep(limit_interval - time_since_last)
-            self._last_request_time = asyncio.get_event_loop().time()
+            self._last_request_time = loop.time()
 
     async def generate_text(self, prompt: str, temperature: Optional[float] = None) -> str:
         """Asynchronously generates text from a prompt."""


### PR DESCRIPTION
The `asyncio.get_event_loop()` function is deprecated in Python 3.10+ when there is no running event loop, and even when there is, `asyncio.get_running_loop()` is the preferred modern alternative within `async` functions.

I replaced all occurrences of `asyncio.get_event_loop().time()` with `asyncio.get_running_loop().time()` (capturing the loop once for efficiency) in `llm_client.py` and the relevant test files. This improves code health and ensures compatibility with future Python versions.

Verification was performed by:
1. Inspecting the modified files to ensure correct application of the changes.
2. Running a standalone script to confirm `asyncio.get_running_loop().time()` works as expected in the environment.
3. Attempting to run the full test suite (though environmental issues with missing dependencies like `dotenv` and `pydantic` prevented a full run, the logic change was manually verified).
4. Obtaining a positive code review and removing temporary test artifacts.

---
*PR created automatically by Jules for task [15233538493844553057](https://jules.google.com/task/15233538493844553057) started by @chottokun*