### PR TITLE
Refactor: Move split_text_into_chunks to utils module

### DIFF
--- a/deep_research_project/core/research_loop.py
+++ b/deep_research_project/core/research_loop.py
@@ -11,28 +11,9 @@ import logging
 import json
 import asyncio
 from typing import List, Optional, Callable
+from .utils import split_text_into_chunks
 
 logger = logging.getLogger(__name__)
-
-
-def split_text_into_chunks(text: str, chunk_size: int, chunk_overlap: int) -> List[str]:
-    """Splits a given text into overlapping chunks."""
-    if not text: return []
-    if chunk_size <= 0: raise ValueError("Chunk size must be positive.")
-    if chunk_overlap < 0 or chunk_overlap >= chunk_size:
-        raise ValueError("Invalid chunk overlap.")
-
-    text_len = len(text)
-    if text_len <= chunk_size: return [text]
-
-    chunks = []
-    idx = 0
-    while idx < text_len:
-        end_idx = idx + chunk_size
-        chunks.append(text[idx:end_idx])
-        if end_idx >= text_len: break
-        idx += (chunk_size - chunk_overlap)
-    return chunks
 
 
 class ResearchLoop:

--- a/deep_research_project/core/utils.py
+++ b/deep_research_project/core/utils.py
@@ -1,0 +1,20 @@
+from typing import List
+
+def split_text_into_chunks(text: str, chunk_size: int, chunk_overlap: int) -> List[str]:
+    """Splits a given text into overlapping chunks."""
+    if not text: return []
+    if chunk_size <= 0: raise ValueError("Chunk size must be positive.")
+    if chunk_overlap < 0 or chunk_overlap >= chunk_size:
+        raise ValueError("Invalid chunk overlap.")
+
+    text_len = len(text)
+    if text_len <= chunk_size: return [text]
+
+    chunks = []
+    idx = 0
+    while idx < text_len:
+        end_idx = idx + chunk_size
+        chunks.append(text[idx:end_idx])
+        if end_idx >= text_len: break
+        idx += (chunk_size - chunk_overlap)
+    return chunks

--- a/deep_research_project/tests/test_core_components.py
+++ b/deep_research_project/tests/test_core_components.py
@@ -5,7 +5,8 @@ from unittest.mock import patch, MagicMock, AsyncMock
 
 # Modules to be tested
 from deep_research_project.config.config import Configuration
-from deep_research_project.core.research_loop import ResearchLoop, split_text_into_chunks
+from deep_research_project.core.research_loop import ResearchLoop
+from deep_research_project.core.utils import split_text_into_chunks
 from deep_research_project.core.state import ResearchState, Source, SearchResult, ResearchPlanModel, Section, KnowledgeGraphModel
 from deep_research_project.tools.llm_client import LLMClient
 


### PR DESCRIPTION
🎯 **What:** Moved `split_text_into_chunks` from `deep_research_project/core/research_loop.py` to `deep_research_project/core/utils.py`.
💡 **Why:** To improve maintainability and readability by separating generic utilities from core business logic.
✅ **Verification:** Verified by running unit tests in `deep_research_project/tests/test_core_components.py` and ensuring all tests passed.
✨ **Result:** The code is now more modular and the utility function is reusable.

---
*PR created automatically by Jules for task [1938797716816579461](https://jules.google.com/task/1938797716816579461) started by @chottokun*