### PR TITLE
🧹 Improve error handling in SearchClient

### DIFF
--- a/deep_research_project/tests/test_search_client.py
+++ b/deep_research_project/tests/test_search_client.py
@@ -1,0 +1,27 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from deep_research_project.tools.search_client import SearchClient, SearchResult
+from deep_research_project.config.config import Configuration
+import asyncio
+
+class TestSearchClient(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.config = MagicMock(spec=Configuration)
+        self.config.SEARCH_API = "duckduckgo"
+
+    @patch('deep_research_project.tools.search_client.DuckDuckGoSearchAPIWrapper')
+    async def test_search_raises_exception(self, MockDDG):
+        # Setup mock to raise exception
+        mock_tool = MockDDG.return_value
+        mock_tool.results.side_effect = Exception("Search API Error")
+
+        client = SearchClient(self.config)
+
+        # New behavior: raises Exception
+        with self.assertRaises(Exception) as context:
+            await client.search("query")
+
+        self.assertIn("Search API Error", str(context.exception))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/deep_research_project/tools/search_client.py
+++ b/deep_research_project/tools/search_client.py
@@ -54,7 +54,7 @@ class SearchClient:
             return await loop.run_in_executor(None, self._sync_search, query, num_results)
         except Exception as e:
             logger.error(f"Error during search with {self.config.SEARCH_API} for query '{query}': {e}", exc_info=True)
-            return []
+            raise
 
     def _sync_search(self, query: str, num_results: int) -> list[SearchResult]:
         if self.config.SEARCH_API == "searxng":


### PR DESCRIPTION
**What:**
Modified `SearchClient.search` in `deep_research_project/tools/search_client.py` to re-raise exceptions instead of returning an empty list.

**Why:**
Swallowing exceptions prevents diagnosing why search might be failing (e.g. API rate limits, network issues). It is better to bubble up the error so it can be handled or logged appropriately by the caller, while maintaining the specific logging context within `SearchClient`.

**Verification:**
- Created `deep_research_project/tests/test_search_client.py` which mocks the search tool to raise an exception and asserts that `SearchClient.search` raises it.
- Verified that `deep_research_project/tests/test_core_components.py` still passes.
- Verified that `ResearchLoop` handles exceptions gracefully.

**Result:**
Search errors are now propagated, improving observability and debugging capabilities.

---
*PR created automatically by Jules for task [4951204634429033150](https://jules.google.com/task/4951204634429033150) started by @chottokun*