### PR TITLE
🔒 Fix SSRF in Content Retriever

### DIFF
--- a/deep_research_project/tests/test_security_ssrf.py
+++ b/deep_research_project/tests/test_security_ssrf.py
@@ -1,0 +1,106 @@
+import asyncio
+import unittest
+import socket
+from unittest.mock import MagicMock, AsyncMock, patch, call
+from deep_research_project.config.config import Configuration
+from deep_research_project.tools.content_retriever import ContentRetriever
+
+class TestSSRF(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.config = MagicMock(spec=Configuration)
+        self.config.MAX_TEXT_LENGTH_PER_SOURCE_CHARS = 1000
+        self.config.PROCESS_PDF_FILES = False
+        self.config.RETRIEVAL_TIMEOUT = 1
+        self.retriever = ContentRetriever(self.config)
+
+    async def test_block_private_ip_direct(self):
+        url = "http://192.168.1.1"
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client_cls.return_value.__aenter__.return_value = mock_client
+
+            result = await self.retriever.retrieve_and_extract(url)
+
+            self.assertEqual(result, "")
+            mock_client.get.assert_not_called()
+
+    async def test_block_localhost(self):
+        url = "http://localhost"
+
+        # Mock getaddrinfo to return 127.0.0.1
+        # Note: We patch where it is looked up. Since content_retriever imports socket, and uses socket.getaddrinfo
+        # we can patch socket.getaddrinfo.
+        with patch("socket.getaddrinfo") as mock_getaddrinfo:
+            mock_getaddrinfo.return_value = [(socket.AF_INET, socket.SOCK_STREAM, 6, '', ('127.0.0.1', 80))]
+
+            with patch("httpx.AsyncClient") as mock_client_cls:
+                mock_client = AsyncMock()
+                mock_client_cls.return_value.__aenter__.return_value = mock_client
+
+                result = await self.retriever.retrieve_and_extract(url)
+                self.assertEqual(result, "")
+                mock_client.get.assert_not_called()
+
+    async def test_allow_public_ip(self):
+        url = "http://example.com"
+
+        with patch("socket.getaddrinfo") as mock_getaddrinfo:
+            # 93.184.216.34 is example.com
+            mock_getaddrinfo.return_value = [(socket.AF_INET, socket.SOCK_STREAM, 6, '', ('93.184.216.34', 80))]
+
+            with patch("httpx.AsyncClient") as mock_client_cls:
+                mock_client = AsyncMock()
+                mock_client_cls.return_value.__aenter__.return_value = mock_client
+
+                mock_response = MagicMock()
+                mock_response.status_code = 200
+                mock_response.headers = {"Content-Type": "text/html"}
+                mock_response.text = "<html><body>Safe Content</body></html>"
+                mock_response.is_redirect = False
+                mock_response.raise_for_status = MagicMock()
+
+                mock_client.get.return_value = mock_response
+
+                result = await self.retriever.retrieve_and_extract(url)
+
+                mock_client.get.assert_awaited_with(url)
+                self.assertIn("Safe Content", result)
+
+    async def test_block_redirect_to_private(self):
+        url = "http://example.com/redirect"
+        target_url = "http://192.168.1.1/secret"
+
+        def getaddrinfo_side_effect(host, port, family=0, type=0, proto=0, flags=0):
+            # Check host string (it might be bytes or str depending on usage, but usually str here)
+            if "example.com" in str(host):
+                return [(socket.AF_INET, socket.SOCK_STREAM, 6, '', ('93.184.216.34', 80))]
+            elif "192.168.1.1" in str(host):
+                return [(socket.AF_INET, socket.SOCK_STREAM, 6, '', ('192.168.1.1', 80))]
+            raise socket.gaierror("Unknown host")
+
+        with patch("socket.getaddrinfo", side_effect=getaddrinfo_side_effect):
+            with patch("httpx.AsyncClient") as mock_client_cls:
+                mock_client = AsyncMock()
+                mock_client_cls.return_value.__aenter__.return_value = mock_client
+
+                # First response: Redirect
+                response1 = MagicMock()
+                response1.status_code = 302
+                response1.is_redirect = True
+                response1.headers = {"Location": target_url}
+                # When get is called first time, return redirect
+                # When get is called second time (if it were), return forbidden/success
+
+                mock_client.get.return_value = response1
+
+                result = await self.retriever.retrieve_and_extract(url)
+
+                self.assertEqual(result, "")
+
+                # Verify get was called exactly once (for the initial URL)
+                self.assertEqual(mock_client.get.await_count, 1)
+                mock_client.get.assert_awaited_with(url)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/deep_research_project/tools/content_retriever.py
+++ b/deep_research_project/tools/content_retriever.py
@@ -3,6 +3,9 @@ from bs4 import BeautifulSoup
 import logging
 import io
 import asyncio
+import socket
+import ipaddress
+from urllib.parse import urlparse, urljoin
 from pypdf import PdfReader
 from pypdf.errors import PdfReadError
 from deep_research_project.config.config import Configuration
@@ -53,6 +56,38 @@ class ContentRetriever:
         except Exception as e:
             logger.error(f"Error in progress_callback: {e}")
 
+    async def _validate_url(self, url: str):
+        """Validates that the URL does not point to a private or restricted IP address."""
+        try:
+            parsed = urlparse(url)
+            hostname = parsed.hostname
+            if not hostname:
+                raise ValueError(f"Invalid URL: {url}")
+
+            # Resolve hostname to IP addresses
+            loop = asyncio.get_running_loop()
+            # Use run_in_executor for blocking socket call
+            # 0 for port means any port, 0 for family/socktype means any
+            addr_info = await loop.run_in_executor(None, socket.getaddrinfo, hostname, 0)
+
+            for _, _, _, _, sockaddr in addr_info:
+                ip = sockaddr[0]
+                ip_obj = ipaddress.ip_address(ip)
+
+                # Check for private, loopback, or other restricted ranges
+                if (ip_obj.is_private or ip_obj.is_loopback or
+                    ip_obj.is_link_local or ip_obj.is_multicast or
+                    ip_obj.is_reserved):
+                    raise ValueError(f"Access to restricted IP {ip} is forbidden")
+
+        except socket.gaierror:
+            # If we can't resolve it, it might be invalid or internal DNS that fails externally.
+            raise ValueError(f"Could not resolve hostname: {parsed.hostname}")
+        except Exception as e:
+            if isinstance(e, ValueError):
+                raise e
+            raise ValueError(f"Error validating URL {url}: {e}")
+
     async def retrieve_and_extract(self, url: str, timeout: Optional[int] = None) -> str:
         """Asynchronously fetches content from a URL and extracts clean text."""
         logger.info(f"Attempting to retrieve and extract content from: {url}")
@@ -60,29 +95,57 @@ class ContentRetriever:
         request_timeout = timeout or getattr(self.config, "RETRIEVAL_TIMEOUT", 15)
 
         try:
-            async with httpx.AsyncClient(headers=self.headers, follow_redirects=True, timeout=request_timeout) as client:
-                response = await client.get(url)
+            # We use follow_redirects=False to manually validate each redirect
+            async with httpx.AsyncClient(headers=self.headers, follow_redirects=False, timeout=request_timeout) as client:
+                current_url = url
+                response = None
+                max_redirects = 10
+
+                for _ in range(max_redirects):
+                    # Validate the URL before fetching
+                    await self._validate_url(current_url)
+
+                    response = await client.get(current_url)
+
+                    # Check for redirects
+                    if response.is_redirect:
+                        location = response.headers.get("Location")
+                        if not location:
+                            break
+
+                        # Handle relative redirects
+                        current_url = urljoin(current_url, location)
+                        continue
+                    else:
+                        break
+                else:
+                    logger.warning(f"Max redirects exceeded for {url}")
+                    return ""
+
+                if response is None:
+                     return ""
+
                 response.raise_for_status()
 
                 content_type = response.headers.get("Content-Type", "").lower()
 
                 # PDF Processing
-                if (self.config.PROCESS_PDF_FILES and ("application/pdf" in content_type or url.lower().endswith(".pdf"))):
-                    return await self._process_pdf(response.content, url)
+                if (self.config.PROCESS_PDF_FILES and ("application/pdf" in content_type or current_url.lower().endswith(".pdf"))):
+                    return await self._process_pdf(response.content, current_url)
 
                 # HTML Processing
                 elif "text/html" in content_type:
-                    text_content = self.extract_text(response.text, url=url)
+                    text_content = self.extract_text(response.text, url=current_url)
                     if text_content:
-                        await self._call_progress(f"Successfully extracted {len(text_content)} chars from HTML: {url}")
-                    return self._apply_truncation(text_content, url)
+                        await self._call_progress(f"Successfully extracted {len(text_content)} chars from HTML: {current_url}")
+                    return self._apply_truncation(text_content, current_url)
 
                 # Fallback for plain text
                 elif "text/" in content_type:
-                    return self._apply_truncation(response.text.strip(), url)
+                    return self._apply_truncation(response.text.strip(), current_url)
 
                 else:
-                    logger.warning(f"Unsupported content type '{content_type}' for {url}.")
+                    logger.warning(f"Unsupported content type '{content_type}' for {current_url}.")
                     return ""
 
         except Exception as e:


### PR DESCRIPTION
This PR addresses a Server-Side Request Forgery (SSRF) vulnerability in `deep_research_project/tools/content_retriever.py`.

**Risk:**
The vulnerability allowed the application to fetch content from internal or private IP addresses if a user provided a malicious URL or if a fetched URL redirected to a private IP. This could expose sensitive internal services.

**Solution:**
1.  **Input Validation:** Introduced `_validate_url` which resolves the hostname to an IP address and verifies it against a list of restricted ranges (private, loopback, link-local, multicast, reserved) using `ipaddress` library.
2.  **Redirect Protection:** Disabled automatic redirects in `httpx` and implemented a manual loop that validates the URL *before* following each redirect.
3.  **Testing:** Added comprehensive tests in `deep_research_project/tests/test_security_ssrf.py` covering direct access, localhost, public IPs, and redirect scenarios. Updated existing unit tests to mock DNS resolution.


---
*PR created automatically by Jules for task [10537425371293738055](https://jules.google.com/task/10537425371293738055) started by @chottokun*