### PR TITLE
Refactor SearchResult and Source to use Pydantic BaseModel

### DIFF
--- a/deep_research_project/chainlit_app.py
+++ b/deep_research_project/chainlit_app.py
@@ -150,7 +150,7 @@ async def handle_interactive_steps(loop: ResearchLoop, state: ResearchState):
             content = "### Select sources to summarize:\n"
             actions = []
             for i, res in enumerate(state.search_results):
-                content += f"{i+1}. [{res['title']}]({res['link']})\n"
+                content += f"{i+1}. [{res.title}]({res.link})\n"
                 actions.append(cl.Action(name="select_source", payload={"value": str(i)}, label=f"Source {i+1}"))
 
             actions.append(cl.Action(name="summarize_all", payload={"value": "all"}, label="All Sources"))

--- a/deep_research_project/core/research_loop.py
+++ b/deep_research_project/core/research_loop.py
@@ -139,7 +139,7 @@ class ResearchLoop:
             self.state.pending_source_selection = bool(results)
             if self.progress_callback:
                 if results:
-                    results_str = "\n".join([f"- [{r['title']}]({r['link']})" for r in results])
+                    results_str = "\n".join([f"- [{r.title}]({r.link})" for r in results])
                     await self.progress_callback(f"Found {len(results)} potential sources:\n{results_str}")
                 else:
                     await self.progress_callback("No search results found.")
@@ -156,7 +156,7 @@ class ResearchLoop:
             return
 
         if self.progress_callback:
-             sources_titles = ", ".join([r['title'] for r in selected_results])
+             sources_titles = ", ".join([r.title for r in selected_results])
              await self.progress_callback(f"Summarizing {len(selected_results)} sources: {sources_titles}...")
 
         all_chunk_summaries = []
@@ -164,13 +164,13 @@ class ResearchLoop:
         if self.state.fetched_content is None: self.state.fetched_content = {}
 
         for result in selected_results:
-            url = result['link']
+            url = result.link
             if url not in self.state.fetched_content:
                 if self.config.USE_SNIPPETS_ONLY_MODE:
-                    content = result.get('snippet', '')
+                    content = result.snippet
                 else:
                     content = await self.content_retriever.retrieve_and_extract(url)
-                    if not content: content = result.get('snippet', '')
+                    if not content: content = result.snippet
                 self.state.fetched_content[url] = content
 
             content = self.state.fetched_content[url]
@@ -215,8 +215,8 @@ class ResearchLoop:
             if self.progress_callback: await self.progress_callback("Summary update complete.")
 
         for res in selected_results:
-            if res['link'] not in [s['link'] for s in self.state.sources_gathered]:
-                self.state.sources_gathered.append(Source(title=res['title'], link=res['link']))
+            if res.link not in [s.link for s in self.state.sources_gathered]:
+                self.state.sources_gathered.append(Source(title=res.title, link=res.link))
 
         self.state.pending_source_selection = False
         # await self._extract_entities_and_relations() # Now handled in parallel with reflection
@@ -302,10 +302,10 @@ class ResearchLoop:
                 if sec['summary']:
                     full_context += f"\n\n### {sec['title']}\n{sec['summary']}"
                 for s in sec['sources']:
-                    if s['link'] not in [src['link'] for src in all_sources]:
+                    if s.link not in [src.link for src in all_sources]:
                         all_sources.append(s)
 
-        source_list_str = "\n".join([f"[{i+1}] {s['title']} ({s['link']})" for i, s in enumerate(all_sources)])
+        source_list_str = "\n".join([f"[{i+1}] {s.title} ({s.link})" for i, s in enumerate(all_sources)])
 
         if not source_list_str:
             source_info = "No specific web sources were found or selected for this research."

--- a/deep_research_project/core/state.py
+++ b/deep_research_project/core/state.py
@@ -1,12 +1,12 @@
 from typing import List, Dict, Optional, TypedDict
 from pydantic import BaseModel, Field
 
-class SearchResult(TypedDict):
+class SearchResult(BaseModel):
     title: str
     link: str
     snippet: str # Or any other relevant fields from search API
 
-class Source(TypedDict):
+class Source(BaseModel):
     title: str
     link: str
 

--- a/deep_research_project/streamlit_app.py
+++ b/deep_research_project/streamlit_app.py
@@ -147,7 +147,7 @@ def main():
             st.subheader("Select Sources")
             selected = []
             for res in state.search_results:
-                if st.checkbox(res['title'], key=f"src_{res['link']}"):
+                if st.checkbox(res.title, key=f"src_{res.link}"):
                     selected.append(res)
             if st.button("Summarize Selected"):
                 with st.status("Summarizing selected sources and continuing research...", expanded=True) as status:


### PR DESCRIPTION
This PR refactors `SearchResult` and `Source` in `deep_research_project/core/state.py` to use Pydantic `BaseModel` instead of `TypedDict`. This improves type safety and validation consistency across the codebase. It also updates the consuming code in `research_loop.py`, `chainlit_app.py`, and `streamlit_app.py` to access fields using dot notation instead of dictionary keys. Existing tests were verified to pass.

---
*PR created automatically by Jules for task [18315687824706521179](https://jules.google.com/task/18315687824706521179) started by @chottokun*