### PR TITLE
🧹 Deduplicate Query Sanitization Logic

### DIFF
--- a/deep_research_project/core/planning.py
+++ b/deep_research_project/core/planning.py
@@ -7,6 +7,7 @@ from deep_research_project.core.prompts import (
     RESEARCH_PLAN_PROMPT_JA, RESEARCH_PLAN_PROMPT_EN,
     INITIAL_QUERY_PROMPT_JA, INITIAL_QUERY_PROMPT_EN
 )
+from deep_research_project.core.utils import sanitize_query
 
 logger = logging.getLogger(__name__)
 
@@ -81,15 +82,7 @@ class ResearchPlanner:
 
     def _sanitize_query(self, query: str) -> str:
         """Cleans and truncates the query to prevent API errors."""
-        if not query: return ""
-        # Remove markdown bold/italic/code fences
-        clean = query.strip().replace("**", "").replace("__", "").replace("`", "").replace('"', '')
-        # Take only the first line if multiple lines returned
-        clean = clean.split('\n')[0].strip()
-        # Truncate to a reasonable character length (e.g., 100 characters)
-        if len(clean) > 100:
-            clean = clean[:100].rsplit(' ', 1)[0] # Try to cut at word boundary
-        return clean
+        return sanitize_query(query)
 
     async def regenerate_query(self, original_query: str, topic: str, 
                                section_title: str, language: str) -> str:

--- a/deep_research_project/core/reflection.py
+++ b/deep_research_project/core/reflection.py
@@ -5,6 +5,7 @@ from deep_research_project.config.config import Configuration
 from deep_research_project.tools.llm_client import LLMClient
 from deep_research_project.core.state import KnowledgeGraphModel, Source
 from deep_research_project.core.prompts import KG_EXTRACTION_PROMPT_JA, KG_EXTRACTION_PROMPT_EN
+from deep_research_project.core.utils import sanitize_query
 
 logger = logging.getLogger(__name__)
 
@@ -133,8 +134,6 @@ class ResearchReflector:
                 q = line.split(":")[-1].strip()
                 if q.lower() != "none": 
                     # Sanitize the reflected query similarly to the initial query
-                    q = q.replace("**", "").replace("__", "").replace("`", "").replace('"', '')
-                    if len(q) > 100: q = q[:100]
-                    next_query = q
+                    next_query = sanitize_query(q)
         
         return evaluation, next_query

--- a/deep_research_project/core/utils.py
+++ b/deep_research_project/core/utils.py
@@ -19,3 +19,20 @@ def split_text_into_chunks(text: str, chunk_size: int, chunk_overlap: int) -> Li
             break
         start += (chunk_size - chunk_overlap)
     return chunks
+
+def sanitize_query(query: str) -> str:
+    """Cleans and truncates the query to prevent API errors."""
+    if not query: return ""
+    # Remove markdown bold/italic/code fences
+    clean = query.strip().replace("**", "").replace("__", "").replace("`", "").replace('"', '')
+    # Take only the first line if multiple lines returned
+    clean = clean.split('\n')[0].strip()
+    # Truncate to a reasonable character length (e.g., 100 characters)
+    if len(clean) > 100:
+        # Try to cut at word boundary
+        parts = clean[:100].rsplit(' ', 1)
+        if len(parts) > 1:
+            clean = parts[0]
+        else:
+            clean = clean[:100]
+    return clean

--- a/deep_research_project/tests/test_core_components.py
+++ b/deep_research_project/tests/test_core_components.py
@@ -6,7 +6,7 @@ from unittest.mock import patch, MagicMock, AsyncMock
 # Modules to be tested
 from deep_research_project.config.config import Configuration
 from deep_research_project.core.research_loop import ResearchLoop
-from deep_research_project.core.utils import split_text_into_chunks
+from deep_research_project.core.utils import split_text_into_chunks, sanitize_query
 from deep_research_project.core.state import ResearchState, Source, SearchResult, ResearchPlanModel, Section, KnowledgeGraphModel
 from deep_research_project.tools.llm_client import LLMClient
 
@@ -113,6 +113,25 @@ class TestSplitTextIntoChunks(unittest.TestCase):
         text = "1234567890"
         chunks = split_text_into_chunks(text, 5, 2)
         self.assertEqual(chunks, ["12345", "45678", "7890"])
+
+class TestSanitizeQuery(unittest.TestCase):
+    def test_sanitize_query_basic(self):
+        self.assertEqual(sanitize_query("**bold**"), "bold")
+        self.assertEqual(sanitize_query("`code`"), "code")
+        self.assertEqual(sanitize_query('quoted "query"'), "quoted query")
+
+    def test_sanitize_query_newline(self):
+        self.assertEqual(sanitize_query("line1\nline2"), "line1")
+
+    def test_sanitize_query_truncation(self):
+        long_query = "This is a very long query that should definitely be truncated because it exceeds the one hundred character limit imposed by our utility function"
+        sanitized = sanitize_query(long_query)
+        self.assertTrue(len(sanitized) <= 100)
+        self.assertEqual(sanitized, "This is a very long query that should definitely be truncated because it exceeds the one hundred")
+
+    def test_sanitize_query_empty(self):
+        self.assertEqual(sanitize_query(""), "")
+        self.assertEqual(sanitize_query(None), "")
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The query sanitization logic was duplicated in `planning.py` and `reflection.py`. I extracted this logic into a utility function `sanitize_query` in `core/utils.py`, updated both call sites to use it, and added unit tests to verify the behavior. This ensures that all search queries (initial and reflected) are cleaned and truncated consistently.

---
*PR created automatically by Jules for task [519769024320684093](https://jules.google.com/task/519769024320684093) started by @chottokun*