### PR TITLE
🔒 Fix SSRF via DNS Rebinding in ContentRetriever

### DIFF
--- a/deep_research_project/tests/test_content_retriever.py
+++ b/deep_research_project/tests/test_content_retriever.py
@@ -30,7 +30,10 @@ class TestContentRetriever(unittest.IsolatedAsyncioTestCase):
         await retriever._call_progress("test message")
         async_callback.assert_awaited_once_with("test message")
 
-    async def test_retrieve_and_extract_html(self):
+    @patch("socket.getaddrinfo")
+    async def test_retrieve_and_extract_html(self, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [(None, None, None, None, ("127.0.0.1", 80))]
+
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.headers = {"Content-Type": "text/html"}
@@ -41,16 +44,19 @@ class TestContentRetriever(unittest.IsolatedAsyncioTestCase):
         # We need to mock AsyncClient as a whole or mock the context manager
         with patch("httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
-            mock_client.get.return_value = mock_response
+            mock_client.send.return_value = mock_response
             mock_client.__aenter__.return_value = mock_client
             mock_client_class.return_value = mock_client
 
             text = await retriever.retrieve_and_extract("http://example.com")
             self.assertEqual(text, "Content")
 
+    @patch("socket.getaddrinfo")
     @patch("deep_research_project.tools.content_retriever.PdfReader")
     @patch("httpx.AsyncClient")
-    async def test_retrieve_and_extract_pdf(self, mock_client_class, mock_pdf_reader):
+    async def test_retrieve_and_extract_pdf(self, mock_client_class, mock_pdf_reader, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [(None, None, None, None, ("127.0.0.1", 80))]
+
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.headers = {"Content-Type": "application/pdf"}
@@ -58,7 +64,7 @@ class TestContentRetriever(unittest.IsolatedAsyncioTestCase):
         mock_response.raise_for_status = MagicMock()
 
         mock_client = AsyncMock()
-        mock_client.get.return_value = mock_response
+        mock_client.send.return_value = mock_response
         mock_client.__aenter__.return_value = mock_client
         mock_client_class.return_value = mock_client
 

--- a/deep_research_project/tools/content_retriever.py
+++ b/deep_research_project/tools/content_retriever.py
@@ -55,39 +55,44 @@ class ContentRetriever:
         except Exception as e:
             logger.error(f"Error in progress_callback: {e}")
 
-    async def _validate_url(self, url: str):
-        """Validates that the URL does not point to a private or restricted IP address if configured."""
-        if not getattr(self.config, "BLOCK_LOCAL_IP_ACCESS", False):
-            return
+    async def _resolve_and_validate_url(self, url: str) -> str:
+        """
+        Resolves the hostname in the URL and validates that it does not point
+        to a private or restricted IP address if configured.
+        Returns the resolved IP address.
+        """
+        parsed = urlparse(url)
+        hostname = parsed.hostname
+        if not hostname:
+            raise ValueError(f"Invalid URL: {url}")
 
         try:
-            parsed = urlparse(url)
-            hostname = parsed.hostname
-            if not hostname:
-                raise ValueError(f"Invalid URL: {url}")
-
+            # Check if hostname is already an IP
+            ip_obj = ipaddress.ip_address(hostname)
+            resolved_ips = [str(ip_obj)]
+        except ValueError:
             # Resolve hostname to IP addresses
             loop = asyncio.get_running_loop()
-            # Use run_in_executor for blocking socket call
-            addr_info = await loop.run_in_executor(None, socket.getaddrinfo, hostname, 0)
+            try:
+                addr_info = await loop.run_in_executor(None, socket.getaddrinfo, hostname, 0)
+                resolved_ips = [sockaddr[0] for _, _, _, _, sockaddr in addr_info]
+            except socket.gaierror:
+                raise ValueError(f"Could not resolve hostname: {hostname}")
 
-            for _, _, _, _, sockaddr in addr_info:
-                ip = sockaddr[0]
+        if not resolved_ips:
+            raise ValueError(f"No IP addresses found for hostname: {hostname}")
+
+        # Validate IPs if restricted
+        if getattr(self.config, "BLOCK_LOCAL_IP_ACCESS", False):
+            for ip in resolved_ips:
                 ip_obj = ipaddress.ip_address(ip)
-
-                # Check for private, loopback, or other restricted ranges
                 if (ip_obj.is_private or ip_obj.is_loopback or
                     ip_obj.is_link_local or ip_obj.is_multicast or
                     ip_obj.is_reserved):
                     raise ValueError(f"Access to restricted IP {ip} is forbidden")
 
-        except socket.gaierror:
-            # If we can't resolve it, it might be invalid or internal DNS that fails externally.
-            raise ValueError(f"Could not resolve hostname: {parsed.hostname}")
-        except Exception as e:
-            if isinstance(e, ValueError):
-                raise e
-            raise ValueError(f"Error validating URL {url}: {e}")
+        # Return the first IP
+        return resolved_ips[0]
 
     async def retrieve_and_extract(self, url: str, timeout: Optional[int] = None) -> str:
         """Asynchronously fetches content from a URL and extracts clean text."""
@@ -103,14 +108,38 @@ class ContentRetriever:
                 max_redirects = 10
 
                 for _ in range(max_redirects):
-                    # Validate the URL before fetching (only if BLOCK_LOCAL_IP_ACCESS is enabled)
+                    # Resolve and validate the URL before fetching
                     try:
-                        await self._validate_url(current_url)
+                        resolved_ip = await self._resolve_and_validate_url(current_url)
                     except ValueError as ve:
-                        logger.warning(f"URL validation failed: {ve}")
+                        logger.warning(f"URL validation failed for {current_url}: {ve}")
                         return ""
 
-                    response = await client.get(current_url)
+                    parsed_url = urlparse(current_url)
+                    # Construct pinned URL using IP
+                    # Handle both http and https, and preserve port if present
+                    port_str = f":{parsed_url.port}" if parsed_url.port else ""
+
+                    # Handle IPv6 brackets in URL
+                    ip_for_url = resolved_ip
+                    if ":" in resolved_ip and not resolved_ip.startswith("["):
+                        ip_for_url = f"[{resolved_ip}]"
+
+                    pinned_url = f"{parsed_url.scheme}://{ip_for_url}{port_str}{parsed_url.path}"
+                    if parsed_url.query:
+                        pinned_url += f"?{parsed_url.query}"
+                    if parsed_url.fragment:
+                        pinned_url += f"#{parsed_url.fragment}"
+
+                    request_headers = self.headers.copy()
+                    # Host header should include the port if it's non-standard
+                    request_headers["Host"] = parsed_url.netloc
+
+                    req = httpx.Request("GET", pinned_url, headers=request_headers)
+                    if parsed_url.scheme == "https":
+                        req.extensions["sni_hostname"] = parsed_url.hostname.encode()
+
+                    response = await client.send(req)
 
                     # Check for redirects
                     if response.is_redirect:

--- a/test_httpx_pinning.py
+++ b/test_httpx_pinning.py
@@ -1,0 +1,37 @@
+
+import httpx
+import asyncio
+import socket
+
+async def test_dns_pinning():
+    hostname = "www.google.com"
+    try:
+        ip = socket.gethostbyname(hostname)
+        print(f"Resolved {hostname} to {ip}")
+    except Exception as e:
+        print(f"Could not resolve {hostname}: {e}")
+        return
+
+    url = f"https://{ip}/"
+    headers = {"Host": hostname}
+
+    print("\n1. Testing without sni_hostname extension (should fail SSL):")
+    async with httpx.AsyncClient() as client:
+        try:
+            resp = await client.get(url, headers=headers, timeout=5)
+            print(f"Success! Status: {resp.status_code}")
+        except Exception as e:
+            print(f"Failed: {e}")
+
+    print("\n2. Testing with sni_hostname extension:")
+    async with httpx.AsyncClient(timeout=5) as client:
+        try:
+            req = httpx.Request("GET", url, headers=headers)
+            req.extensions["sni_hostname"] = hostname.encode()
+            resp = await client.send(req)
+            print(f"Success! Status: {resp.status_code}")
+        except Exception as e:
+            print(f"Failed: {e}")
+
+if __name__ == "__main__":
+    asyncio.run(test_dns_pinning())


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is Server-Side Request Forgery (SSRF) via DNS Rebinding in the `ContentRetriever` tool.

⚠️ **Risk:** An attacker could bypass IP-based access restrictions (if `BLOCK_LOCAL_IP_ACCESS` is enabled) by using a DNS server that returns a safe IP during validation but a restricted IP (e.g., a private or loopback address) during the actual request. This could allow the attacker to access internal services or sensitive data.

🛡️ **Solution:** Implemented **IP Pinning**. The hostname is resolved and validated once. The resulting IP address is then used directly in the request URL. Correct routing and TLS verification are ensured by manually setting the `Host` header (including port) and the `sni_hostname` extension. Manual redirect handling is used to apply the same validation and pinning logic to every step of a redirect chain. IPv6 addresses are correctly handled by wrapping them in square brackets.

---
*PR created automatically by Jules for task [1896245001891554624](https://jules.google.com/task/1896245001891554624) started by @chottokun*