### PR TITLE
🧹 Centralize Hardcoded Prompts in Core Module

### DIFF
--- a/deep_research_project/core/execution.py
+++ b/deep_research_project/core/execution.py
@@ -6,6 +6,11 @@ from deep_research_project.tools.llm_client import LLMClient
 from deep_research_project.tools.search_client import SearchClient, SearchResult
 from deep_research_project.tools.content_retriever import ContentRetriever
 from deep_research_project.core.utils import split_text_into_chunks
+from deep_research_project.core.prompts import (
+    SUMMARIZE_CHUNK_PROMPT_JA, SUMMARIZE_CHUNK_PROMPT_EN,
+    SUMMARIES_SYNTHESIS_PROMPT_JA, SUMMARIES_SYNTHESIS_PROMPT_EN,
+    RELEVANCE_SCORE_PROMPT_JA, RELEVANCE_SCORE_PROMPT_EN
+)
 
 logger = logging.getLogger(__name__)
 
@@ -59,9 +64,9 @@ class ResearchExecutor:
             async with self.semaphore:
                 if progress_callback: await progress_callback(f"Summarizing chunk from {url}...")
                 if language == "Japanese":
-                    prompt = f"リサーチクエリ: '{query}' のために、このセグメントを要約してください。\n\nセグメント:\n{chunk}"
+                    prompt = SUMMARIZE_CHUNK_PROMPT_JA.format(query=query, chunk=chunk)
                 else:
-                    prompt = f"Summarize this segment for the research query: '{query}'.\n\nSegment:\n{chunk}"
+                    prompt = SUMMARIZE_CHUNK_PROMPT_EN.format(query=query, chunk=chunk)
                 return await self.llm_client.generate_text(prompt=prompt)
 
         chunk_summaries = await asyncio.gather(*[summarize_chunk(c, u) for c, u in all_chunks_info])
@@ -73,9 +78,9 @@ class ResearchExecutor:
         # Final synthesis
         combined = "\n\n---\n\n".join(valid_summaries)
         if language == "Japanese":
-            prompt = f"これらの要約を、クエリ: '{query}' に関する一つの首尾一貫した要約にまとめてください。\n\n要約群:\n{combined}"
+            prompt = SUMMARIES_SYNTHESIS_PROMPT_JA.format(query=query, combined=combined)
         else:
-            prompt = f"Combine these summaries into one coherent summary for query: '{query}'.\n\nSummaries:\n{combined}"
+            prompt = SUMMARIES_SYNTHESIS_PROMPT_EN.format(query=query, combined=combined)
         
         return await self.llm_client.generate_text(prompt=prompt)
 
@@ -85,33 +90,13 @@ class ResearchExecutor:
         Returns a score between 0.0 (not relevant) and 1.0 (highly relevant).
         """
         if language == "Japanese":
-            prompt = f"""クエリ: {query}
-
-検索結果:
-タイトル: {result.title}
-スニペット: {result.snippet}
-
-このページがクエリに関連しているかを 0.0〜1.0 でスコアリングしてください。
-- 1.0: 非常に関連性が高い
-- 0.5: やや関連性がある
-- 0.0: 全く関連性がない
-
-スコアのみを数値で回答してください（例: 0.8）
-"""
+            prompt = RELEVANCE_SCORE_PROMPT_JA.format(
+                query=query, title=result.title, snippet=result.snippet
+            )
         else:
-            prompt = f"""Query: {query}
-
-Search Result:
-Title: {result.title}
-Snippet: {result.snippet}
-
-Score the relevance of this page to the query on a scale of 0.0 to 1.0.
-- 1.0: Highly relevant
-- 0.5: Somewhat relevant
-- 0.0: Not relevant
-
-Respond with only the numeric score (e.g., 0.8)
-"""
+            prompt = RELEVANCE_SCORE_PROMPT_EN.format(
+                query=query, title=result.title, snippet=result.snippet
+            )
         
         try:
             response = await self.llm_client.generate_text(prompt=prompt)

--- a/deep_research_project/core/planning.py
+++ b/deep_research_project/core/planning.py
@@ -5,7 +5,8 @@ from deep_research_project.tools.llm_client import LLMClient
 from deep_research_project.core.state import ResearchPlanModel, Section
 from deep_research_project.core.prompts import (
     RESEARCH_PLAN_PROMPT_JA, RESEARCH_PLAN_PROMPT_EN,
-    INITIAL_QUERY_PROMPT_JA, INITIAL_QUERY_PROMPT_EN
+    INITIAL_QUERY_PROMPT_JA, INITIAL_QUERY_PROMPT_EN,
+    REGENERATE_QUERY_PROMPT_JA, REGENERATE_QUERY_PROMPT_EN
 )
 
 logger = logging.getLogger(__name__)
@@ -106,31 +107,13 @@ class ResearchPlanner:
             A new, potentially more effective search query
         """
         if language == "Japanese":
-            prompt = f"""トピック: {topic}
-セクション: {section_title}
-元のクエリ: {original_query}
-
-このクエリでは関連性の高い検索結果が見つかりませんでした。
-より適切な検索クエリを生成してください。以下の点を考慮してください:
-- より具体的なキーワードを使用
-- 別の表現や類義語を試す
-- 検索範囲を広げる（または狭める）
-
-新しい検索クエリのみを出力してください（説明不要）。
-"""
+            prompt = REGENERATE_QUERY_PROMPT_JA.format(
+                topic=topic, section_title=section_title, original_query=original_query
+            )
         else:
-            prompt = f"""Topic: {topic}
-Section: {section_title}
-Original Query: {original_query}
-
-This query did not yield any relevant search results.
-Generate a more appropriate search query. Consider:
-- Using more specific keywords
-- Trying alternative expressions or synonyms
-- Broadening (or narrowing) the search scope
-
-Output only the new search query (no explanation needed).
-"""
+            prompt = REGENERATE_QUERY_PROMPT_EN.format(
+                topic=topic, section_title=section_title, original_query=original_query
+            )
         
         logger.info(f"Regenerating query for: '{original_query}'")
         raw_query = await self.llm_client.generate_text(prompt=prompt)

--- a/deep_research_project/core/prompts.py
+++ b/deep_research_project/core/prompts.py
@@ -60,3 +60,115 @@ KG_EXTRACTION_PROMPT_EN = (
     "{urls}\n"
     "4. In properties, always include 'section': '{section_title}'."
 )
+
+SUMMARIZE_CHUNK_PROMPT_JA = "リサーチクエリ: '{query}' のために、このセグメントを要約してください。\n\nセグメント:\n{chunk}"
+SUMMARIZE_CHUNK_PROMPT_EN = "Summarize this segment for the research query: '{query}'.\n\nSegment:\n{chunk}"
+
+SUMMARIES_SYNTHESIS_PROMPT_JA = "これらの要約を、クエリ: '{query}' に関する一つの首尾一貫した要約にまとめてください。\n\n要約群:\n{combined}"
+SUMMARIES_SYNTHESIS_PROMPT_EN = "Combine these summaries into one coherent summary for query: '{query}'.\n\nSummaries:\n{combined}"
+
+RELEVANCE_SCORE_PROMPT_JA = """クエリ: {query}
+
+検索結果:
+タイトル: {title}
+スニペット: {snippet}
+
+このページがクエリに関連しているかを 0.0〜1.0 でスコアリングしてください。
+- 1.0: 非常に関連性が高い
+- 0.5: やや関連性がある
+- 0.0: 全く関連性がない
+
+スコアのみを数値で回答してください（例: 0.8）
+"""
+
+RELEVANCE_SCORE_PROMPT_EN = """Query: {query}
+
+Search Result:
+Title: {title}
+Snippet: {snippet}
+
+Score the relevance of this page to the query on a scale of 0.0 to 1.0.
+- 1.0: Highly relevant
+- 0.5: Somewhat relevant
+- 0.0: Not relevant
+
+Respond with only the numeric score (e.g., 0.8)
+"""
+
+REGENERATE_QUERY_PROMPT_JA = """トピック: {topic}
+セクション: {section_title}
+元のクエリ: {original_query}
+
+このクエリでは関連性の高い検索結果が見つかりませんでした。
+より適切な検索クエリを生成してください。以下の点を考慮してください:
+- より具体的なキーワードを使用
+- 別の表現や類義語を試す
+- 検索範囲を広げる（または狭める）
+
+新しい検索クエリのみを出力してください（説明不要）。
+"""
+
+REGENERATE_QUERY_PROMPT_EN = """Topic: {topic}
+Section: {section_title}
+Original Query: {original_query}
+
+This query did not yield any relevant search results.
+Generate a more appropriate search query. Consider:
+- Using more specific keywords
+- Trying alternative expressions or synonyms
+- Broadening (or narrowing) the search scope
+
+Output only the new search query (no explanation needed).
+"""
+
+REFLECT_AND_DECIDE_PROMPT_JA = """リサーチトピック: {topic}
+セクション: {section_title}
+セクションの目的: {section_description}
+現在の要約:
+{accumulated_summary}
+
+このセクションにさらなる調査が必要かどうかを評価してください。
+必要な場合、次に調査すべき具体的な検索クエリを生成してください。
+クエリは以下の条件を満たす必要があります:
+- リサーチトピック '{topic}' との関連性を保つ
+- セクション '{section_title}' の目的に直接関連する
+- これまでの要約で既にカバーされていない新しい側面を探る
+- 具体的で検索エンジンで有効な形式
+
+フォーマット: EVALUATION: <CONTINUE|CONCLUDE>
+QUERY: <次の検索クエリまたは None>"""
+
+REFLECT_AND_DECIDE_PROMPT_EN = """Research Topic: {topic}
+Section: {section_title}
+Section Purpose: {section_description}
+Current Summary:
+{accumulated_summary}
+
+Evaluate if more research is needed for this section.
+If needed, generate a specific search query for the next investigation.
+The query must meet the following criteria:
+- Maintain relevance to the research topic '{topic}'
+- Directly relate to the section '{section_title}' purpose
+- Explore new aspects not already covered in the summary
+- Be specific and effective for search engines
+
+Format: EVALUATION: <CONTINUE|CONCLUDE>
+QUERY: <Next search query or None>"""
+
+FINAL_REPORT_PROMPT_JA = """トピック: {topic} に関する最終リサーチレポートを作成してください。
+
+コンテキスト:
+{full_context}
+
+{source_info}
+
+指示: 包括的で専門的な構成（日本語）にしてください。{citation_instruction}"""
+
+FINAL_REPORT_PROMPT_EN = """Synthesize a final report for: {topic}
+
+Context:
+{full_context}
+
+{source_info}
+
+Instruction: Professional structure. {citation_instruction}"""

--- a/deep_research_project/core/reflection.py
+++ b/deep_research_project/core/reflection.py
@@ -4,7 +4,10 @@ from typing import List, Optional, Tuple, Callable
 from deep_research_project.config.config import Configuration
 from deep_research_project.tools.llm_client import LLMClient
 from deep_research_project.core.state import KnowledgeGraphModel, Source
-from deep_research_project.core.prompts import KG_EXTRACTION_PROMPT_JA, KG_EXTRACTION_PROMPT_EN
+from deep_research_project.core.prompts import (
+    KG_EXTRACTION_PROMPT_JA, KG_EXTRACTION_PROMPT_EN,
+    REFLECT_AND_DECIDE_PROMPT_JA, REFLECT_AND_DECIDE_PROMPT_EN
+)
 
 logger = logging.getLogger(__name__)
 
@@ -92,34 +95,18 @@ class ResearchReflector:
                                  language: str) -> Tuple[str, Optional[str]]:
         """Evaluates if more research is needed for the current context."""
         if language == "Japanese":
-            prompt = (
-                f"リサーチトピック: {topic}\n"
-                f"セクション: {section_title}\n"
-                f"セクションの目的: {section_description}\n"
-                f"現在の要約:\n{accumulated_summary}\n\n"
-                f"このセクションにさらなる調査が必要かどうかを評価してください。\n"
-                f"必要な場合、次に調査すべき具体的な検索クエリを生成してください。\n"
-                f"クエリは以下の条件を満たす必要があります:\n"
-                f"- リサーチトピック '{topic}' との関連性を保つ\n"
-                f"- セクション '{section_title}' の目的に直接関連する\n"
-                f"- これまでの要約で既にカバーされていない新しい側面を探る\n"
-                f"- 具体的で検索エンジンで有効な形式\n\n"
-                f"フォーマット: EVALUATION: <CONTINUE|CONCLUDE>\nQUERY: <次の検索クエリまたは None>"
+            prompt = REFLECT_AND_DECIDE_PROMPT_JA.format(
+                topic=topic,
+                section_title=section_title,
+                section_description=section_description,
+                accumulated_summary=accumulated_summary
             )
         else:
-            prompt = (
-                f"Research Topic: {topic}\n"
-                f"Section: {section_title}\n"
-                f"Section Purpose: {section_description}\n"
-                f"Current Summary:\n{accumulated_summary}\n\n"
-                f"Evaluate if more research is needed for this section.\n"
-                f"If needed, generate a specific search query for the next investigation.\n"
-                f"The query must meet the following criteria:\n"
-                f"- Maintain relevance to the research topic '{topic}'\n"
-                f"- Directly relate to the section '{section_title}' purpose\n"
-                f"- Explore new aspects not already covered in the summary\n"
-                f"- Be specific and effective for search engines\n\n"
-                f"Format: EVALUATION: <CONTINUE|CONCLUDE>\nQUERY: <Next search query or None>"
+            prompt = REFLECT_AND_DECIDE_PROMPT_EN.format(
+                topic=topic,
+                section_title=section_title,
+                section_description=section_description,
+                accumulated_summary=accumulated_summary
             )
 
         response = await self.llm_client.generate_text(prompt=prompt)

--- a/deep_research_project/core/reporting.py
+++ b/deep_research_project/core/reporting.py
@@ -1,6 +1,7 @@
 import logging
 from typing import List
 from deep_research_project.tools.llm_client import LLMClient
+from deep_research_project.core.prompts import FINAL_REPORT_PROMPT_JA, FINAL_REPORT_PROMPT_EN
 
 logger = logging.getLogger(__name__)
 
@@ -36,18 +37,18 @@ class ResearchReporter:
                 citation_instruction = "Use numbered in-text citations like [1] to attribute information."
 
         if language == "Japanese":
-            prompt = (
-                f"トピック: {topic} に関する最終リサーチレポートを作成してください。\n\n"
-                f"コンテキスト:\n{full_context}\n\n"
-                f"{source_info}\n\n"
-                f"指示: 包括的で専門的な構成（日本語）にしてください。{citation_instruction}"
+            prompt = FINAL_REPORT_PROMPT_JA.format(
+                topic=topic,
+                full_context=full_context,
+                source_info=source_info,
+                citation_instruction=citation_instruction
             )
         else:
-            prompt = (
-                f"Synthesize a final report for: {topic}\n\n"
-                f"Context:\n{full_context}\n\n"
-                f"{source_info}\n\n"
-                f"Instruction: Professional structure. {citation_instruction}"
+            prompt = FINAL_REPORT_PROMPT_EN.format(
+                topic=topic,
+                full_context=full_context,
+                source_info=source_info,
+                citation_instruction=citation_instruction
             )
 
         report = await self.llm_client.generate_text(prompt=prompt)


### PR DESCRIPTION
🎯 **What:** Moved hardcoded LLM prompts from `execution.py`, `planning.py`, `reflection.py`, and `reporting.py` into a central `prompts.py` file.

💡 **Why:** Centralizing prompts improves maintainability and readability by separating instructions from core logic. It also simplifies future localization efforts and prompt tuning.

✅ **Verification:** 
- Ran the full test suite (`uv run python -m unittest discover deep_research_project/tests/`) - all 48 tests passed.
- Verified all `prompt =` assignments in the affected files now use constants from `prompts.py`.
- Performed a code review with the automated tool, which confirmed the refactoring is high-quality and safe.

✨ **Result:** A more modular and maintainable codebase where LLM interaction templates are consolidated in one location.

---
*PR created automatically by Jules for task [16153142082864007644](https://jules.google.com/task/16153142082864007644) started by @chottokun*