### PR TITLE
🧹 Centralize hardcoded prompts in core modules

### DIFF
--- a/deep_research_project/core/execution.py
+++ b/deep_research_project/core/execution.py
@@ -6,6 +6,11 @@ from deep_research_project.tools.llm_client import LLMClient
 from deep_research_project.tools.search_client import SearchClient, SearchResult
 from deep_research_project.tools.content_retriever import ContentRetriever
 from deep_research_project.core.utils import split_text_into_chunks
+from deep_research_project.core.prompts import (
+    SUMMARIZE_CHUNK_PROMPT_JA, SUMMARIZE_CHUNK_PROMPT_EN,
+    SYNTHESIZE_SUMMARY_PROMPT_JA, SYNTHESIZE_SUMMARY_PROMPT_EN,
+    RELEVANCE_SCORE_PROMPT_JA, RELEVANCE_SCORE_PROMPT_EN
+)
 
 logger = logging.getLogger(__name__)
 
@@ -59,9 +64,9 @@ class ResearchExecutor:
             async with self.semaphore:
                 if progress_callback: await progress_callback(f"Summarizing chunk from {url}...")
                 if language == "Japanese":
-                    prompt = f"リサーチクエリ: '{query}' のために、このセグメントを要約してください。\n\nセグメント:\n{chunk}"
+                    prompt = SUMMARIZE_CHUNK_PROMPT_JA.format(query=query, chunk=chunk)
                 else:
-                    prompt = f"Summarize this segment for the research query: '{query}'.\n\nSegment:\n{chunk}"
+                    prompt = SUMMARIZE_CHUNK_PROMPT_EN.format(query=query, chunk=chunk)
                 return await self.llm_client.generate_text(prompt=prompt)
 
         chunk_summaries = await asyncio.gather(*[summarize_chunk(c, u) for c, u in all_chunks_info])
@@ -73,9 +78,9 @@ class ResearchExecutor:
         # Final synthesis
         combined = "\n\n---\n\n".join(valid_summaries)
         if language == "Japanese":
-            prompt = f"これらの要約を、クエリ: '{query}' に関する一つの首尾一貫した要約にまとめてください。\n\n要約群:\n{combined}"
+            prompt = SYNTHESIZE_SUMMARY_PROMPT_JA.format(query=query, combined_summaries=combined)
         else:
-            prompt = f"Combine these summaries into one coherent summary for query: '{query}'.\n\nSummaries:\n{combined}"
+            prompt = SYNTHESIZE_SUMMARY_PROMPT_EN.format(query=query, combined_summaries=combined)
         
         return await self.llm_client.generate_text(prompt=prompt)
 
@@ -85,33 +90,13 @@ class ResearchExecutor:
         Returns a score between 0.0 (not relevant) and 1.0 (highly relevant).
         """
         if language == "Japanese":
-            prompt = f"""クエリ: {query}
-
-検索結果:
-タイトル: {result.title}
-スニペット: {result.snippet}
-
-このページがクエリに関連しているかを 0.0〜1.0 でスコアリングしてください。
-- 1.0: 非常に関連性が高い
-- 0.5: やや関連性がある
-- 0.0: 全く関連性がない
-
-スコアのみを数値で回答してください（例: 0.8）
-"""
+            prompt = RELEVANCE_SCORE_PROMPT_JA.format(
+                query=query, title=result.title, snippet=result.snippet
+            )
         else:
-            prompt = f"""Query: {query}
-
-Search Result:
-Title: {result.title}
-Snippet: {result.snippet}
-
-Score the relevance of this page to the query on a scale of 0.0 to 1.0.
-- 1.0: Highly relevant
-- 0.5: Somewhat relevant
-- 0.0: Not relevant
-
-Respond with only the numeric score (e.g., 0.8)
-"""
+            prompt = RELEVANCE_SCORE_PROMPT_EN.format(
+                query=query, title=result.title, snippet=result.snippet
+            )
         
         try:
             response = await self.llm_client.generate_text(prompt=prompt)

--- a/deep_research_project/core/planning.py
+++ b/deep_research_project/core/planning.py
@@ -5,7 +5,8 @@ from deep_research_project.tools.llm_client import LLMClient
 from deep_research_project.core.state import ResearchPlanModel, Section
 from deep_research_project.core.prompts import (
     RESEARCH_PLAN_PROMPT_JA, RESEARCH_PLAN_PROMPT_EN,
-    INITIAL_QUERY_PROMPT_JA, INITIAL_QUERY_PROMPT_EN
+    INITIAL_QUERY_PROMPT_JA, INITIAL_QUERY_PROMPT_EN,
+    QUERY_REGEN_PROMPT_JA, QUERY_REGEN_PROMPT_EN
 )
 
 logger = logging.getLogger(__name__)
@@ -106,31 +107,17 @@ class ResearchPlanner:
             A new, potentially more effective search query
         """
         if language == "Japanese":
-            prompt = f"""トピック: {topic}
-セクション: {section_title}
-元のクエリ: {original_query}
-
-このクエリでは関連性の高い検索結果が見つかりませんでした。
-より適切な検索クエリを生成してください。以下の点を考慮してください:
-- より具体的なキーワードを使用
-- 別の表現や類義語を試す
-- 検索範囲を広げる（または狭める）
-
-新しい検索クエリのみを出力してください（説明不要）。
-"""
+            prompt = QUERY_REGEN_PROMPT_JA.format(
+                topic=topic,
+                section_title=section_title,
+                original_query=original_query
+            )
         else:
-            prompt = f"""Topic: {topic}
-Section: {section_title}
-Original Query: {original_query}
-
-This query did not yield any relevant search results.
-Generate a more appropriate search query. Consider:
-- Using more specific keywords
-- Trying alternative expressions or synonyms
-- Broadening (or narrowing) the search scope
-
-Output only the new search query (no explanation needed).
-"""
+            prompt = QUERY_REGEN_PROMPT_EN.format(
+                topic=topic,
+                section_title=section_title,
+                original_query=original_query
+            )
         
         logger.info(f"Regenerating query for: '{original_query}'")
         raw_query = await self.llm_client.generate_text(prompt=prompt)

--- a/deep_research_project/core/prompts.py
+++ b/deep_research_project/core/prompts.py
@@ -60,3 +60,135 @@ KG_EXTRACTION_PROMPT_EN = (
     "{urls}\n"
     "4. In properties, always include 'section': '{section_title}'."
 )
+
+# Reporting prompts
+FINAL_REPORT_PROMPT_JA = (
+    "トピック: {topic} に関する最終リサーチレポートを作成してください。\n\n"
+    "コンテキスト:\n{full_context}\n\n"
+    "{source_info}\n\n"
+    "指示: 包括的で専門的な構成（日本語）にしてください。{citation_instruction}"
+)
+
+FINAL_REPORT_PROMPT_EN = (
+    "Synthesize a final report for: {topic}\n\n"
+    "Context:\n{full_context}\n\n"
+    "{source_info}\n\n"
+    "Instruction: Professional structure. {citation_instruction}"
+)
+
+CITATION_INSTRUCTION_JA = "番号付きのインライン引用 [1] を使用して出典を明記してください。"
+CITATION_INSTRUCTION_EN = "Use numbered in-text citations like [1] to attribute information."
+
+NO_CITATION_INSTRUCTION_JA = "引用は使用しないでください。"
+NO_CITATION_INSTRUCTION_EN = "Do not use citations."
+
+SOURCE_INFO_PROMPT_JA = "参考資料:\n{source_list}"
+SOURCE_INFO_PROMPT_EN = "Reference Sources:\n{source_list}"
+
+NO_SOURCE_INFO_MSG_JA = "Webソースは見つかりませんでした。"
+NO_SOURCE_INFO_MSG_EN = "No web sources were found."
+
+# Planning prompts
+QUERY_REGEN_PROMPT_JA = (
+    "トピック: {topic}\n"
+    "セクション: {section_title}\n"
+    "元のクエリ: {original_query}\n\n"
+    "このクエリでは関連性の高い検索結果が見つかりませんでした。\n"
+    "より適切な検索クエリを生成してください。以下の点を考慮してください:\n"
+    "- より具体的なキーワードを使用\n"
+    "- 別の表現や類義語を試す\n"
+    "- 検索範囲を広げる（または狭める）\n\n"
+    "新しい検索クエリのみを出力してください（説明不要）。"
+)
+
+QUERY_REGEN_PROMPT_EN = (
+    "Topic: {topic}\n"
+    "Section: {section_title}\n"
+    "Original Query: {original_query}\n\n"
+    "This query did not yield any relevant search results.\n"
+    "Generate a more appropriate search query. Consider:\n"
+    "- Using more specific keywords\n"
+    "- Trying alternative expressions or synonyms\n"
+    "- Broadening (or narrowing) the search scope\n\n"
+    "Output only the new search query (no explanation needed)."
+)
+
+# Execution prompts
+SUMMARIZE_CHUNK_PROMPT_JA = "リサーチクエリ: '{query}' のために、このセグメントを要約してください。\n\nセグメント:\n{chunk}"
+SUMMARIZE_CHUNK_PROMPT_EN = "Summarize this segment for the research query: '{query}'.\n\nSegment:\n{chunk}"
+
+SYNTHESIZE_SUMMARY_PROMPT_JA = "これらの要約を、クエリ: '{query}' に関する一つの首尾一貫した要約にまとめてください。\n\n要約群:\n{combined_summaries}"
+SYNTHESIZE_SUMMARY_PROMPT_EN = "Combine these summaries into one coherent summary for query: '{query}'.\n\nSummaries:\n{combined_summaries}"
+
+RELEVANCE_SCORE_PROMPT_JA = (
+    "クエリ: {query}\n\n"
+    "検索結果:\n"
+    "タイトル: {title}\n"
+    "スニペット: {snippet}\n\n"
+    "このページがクエリに関連しているかを 0.0〜1.0 でスコアリングしてください。\n"
+    "- 1.0: 非常に関連性が高い\n"
+    "- 0.5: やや関連性がある\n"
+    "- 0.0: 全く関連性がない\n\n"
+    "スコアのみを数値で回答してください（例: 0.8）"
+)
+
+RELEVANCE_SCORE_PROMPT_EN = (
+    "Query: {query}\n\n"
+    "Search Result:\n"
+    "Title: {title}\n"
+    "Snippet: {snippet}\n\n"
+    "Score the relevance of this page to the query on a scale of 0.0 to 1.0.\n"
+    "- 1.0: Highly relevant\n"
+    "- 0.5: Somewhat relevant\n"
+    "- 0.0: Not relevant\n\n"
+    "Respond with only the numeric score (e.g., 0.8)"
+)
+
+# Reflection prompts
+REFLECTION_PROMPT_JA = (
+    "リサーチトピック: {topic}\n"
+    "セクション: {section_title}\n"
+    "セクションの目的: {section_description}\n"
+    "現在の要約:\n{accumulated_summary}\n\n"
+    "このセクションにさらなる調査が必要かどうかを評価してください。\n"
+    "必要な場合、次に調査すべき具体的な検索クエリを生成してください。\n"
+    "クエリは以下の条件を満たす必要があります:\n"
+    "- リサーチトピック '{topic}' との関連性を保つ\n"
+    "- セクション '{section_title}' の目的に直接関連する\n"
+    "- これまでの要約で既にカバーされていない新しい側面を探る\n"
+    "- 具体的で検索エンジンで有効な形式\n\n"
+    "フォーマット: EVALUATION: <CONTINUE|CONCLUDE>\nQUERY: <次の検索クエリまたは None>"
+)
+
+REFLECTION_PROMPT_EN = (
+    "Research Topic: {topic}\n"
+    "Section: {section_title}\n"
+    "Section Purpose: {section_description}\n"
+    "Current Summary:\n{accumulated_summary}\n\n"
+    "Evaluate if more research is needed for this section.\n"
+    "If needed, generate a specific search query for the next investigation.\n"
+    "The query must meet the following criteria:\n"
+    "- Maintain relevance to the research topic '{topic}'\n"
+    "- Directly relate to the section '{section_title}' purpose\n"
+    "- Explore new aspects not already covered in the summary\n"
+    "- Be specific and effective for search engines\n\n"
+    "Format: EVALUATION: <CONTINUE|CONCLUDE>\nQUERY: <Next search query or None>"
+)
+
+# Research Loop messages
+NO_INFO_FOUND_MSG_JA = "クエリ「{query}」に関連する情報が見つかりませんでした。"
+NO_INFO_FOUND_MSG_EN = "No relevant information found for query: '{query}'"
+
+FOLLOW_UP_PROMPT_JA = (
+    "以下のリサーチレポートに基づいて、ユーザーのフォローアップ質問に答えてください。\n\n"
+    "レポート:\n{final_report}\n\n"
+    "ユーザーの質問: {question}\n\n"
+    "レポートの内容のみに基づいて、明確で簡潔な回答を提供してください。回答は日本語で行ってください。"
+)
+
+FOLLOW_UP_PROMPT_EN = (
+    "Based on the following research report, answer the user's follow-up question.\n\n"
+    "Report:\n{final_report}\n\n"
+    "User Question: {question}\n\n"
+    "Provide a clear and concise answer based only on the report content."
+)

--- a/deep_research_project/core/reflection.py
+++ b/deep_research_project/core/reflection.py
@@ -4,7 +4,10 @@ from typing import List, Optional, Tuple, Callable
 from deep_research_project.config.config import Configuration
 from deep_research_project.tools.llm_client import LLMClient
 from deep_research_project.core.state import KnowledgeGraphModel, Source
-from deep_research_project.core.prompts import KG_EXTRACTION_PROMPT_JA, KG_EXTRACTION_PROMPT_EN
+from deep_research_project.core.prompts import (
+    KG_EXTRACTION_PROMPT_JA, KG_EXTRACTION_PROMPT_EN,
+    REFLECTION_PROMPT_JA, REFLECTION_PROMPT_EN
+)
 
 logger = logging.getLogger(__name__)
 
@@ -92,34 +95,18 @@ class ResearchReflector:
                                  language: str) -> Tuple[str, Optional[str]]:
         """Evaluates if more research is needed for the current context."""
         if language == "Japanese":
-            prompt = (
-                f"リサーチトピック: {topic}\n"
-                f"セクション: {section_title}\n"
-                f"セクションの目的: {section_description}\n"
-                f"現在の要約:\n{accumulated_summary}\n\n"
-                f"このセクションにさらなる調査が必要かどうかを評価してください。\n"
-                f"必要な場合、次に調査すべき具体的な検索クエリを生成してください。\n"
-                f"クエリは以下の条件を満たす必要があります:\n"
-                f"- リサーチトピック '{topic}' との関連性を保つ\n"
-                f"- セクション '{section_title}' の目的に直接関連する\n"
-                f"- これまでの要約で既にカバーされていない新しい側面を探る\n"
-                f"- 具体的で検索エンジンで有効な形式\n\n"
-                f"フォーマット: EVALUATION: <CONTINUE|CONCLUDE>\nQUERY: <次の検索クエリまたは None>"
+            prompt = REFLECTION_PROMPT_JA.format(
+                topic=topic,
+                section_title=section_title,
+                section_description=section_description,
+                accumulated_summary=accumulated_summary
             )
         else:
-            prompt = (
-                f"Research Topic: {topic}\n"
-                f"Section: {section_title}\n"
-                f"Section Purpose: {section_description}\n"
-                f"Current Summary:\n{accumulated_summary}\n\n"
-                f"Evaluate if more research is needed for this section.\n"
-                f"If needed, generate a specific search query for the next investigation.\n"
-                f"The query must meet the following criteria:\n"
-                f"- Maintain relevance to the research topic '{topic}'\n"
-                f"- Directly relate to the section '{section_title}' purpose\n"
-                f"- Explore new aspects not already covered in the summary\n"
-                f"- Be specific and effective for search engines\n\n"
-                f"Format: EVALUATION: <CONTINUE|CONCLUDE>\nQUERY: <Next search query or None>"
+            prompt = REFLECTION_PROMPT_EN.format(
+                topic=topic,
+                section_title=section_title,
+                section_description=section_description,
+                accumulated_summary=accumulated_summary
             )
 
         response = await self.llm_client.generate_text(prompt=prompt)

--- a/deep_research_project/core/reporting.py
+++ b/deep_research_project/core/reporting.py
@@ -1,6 +1,13 @@
 import logging
 from typing import List
 from deep_research_project.tools.llm_client import LLMClient
+from deep_research_project.core.prompts import (
+    FINAL_REPORT_PROMPT_JA, FINAL_REPORT_PROMPT_EN,
+    CITATION_INSTRUCTION_JA, CITATION_INSTRUCTION_EN,
+    NO_CITATION_INSTRUCTION_JA, NO_CITATION_INSTRUCTION_EN,
+    SOURCE_INFO_PROMPT_JA, SOURCE_INFO_PROMPT_EN,
+    NO_SOURCE_INFO_MSG_JA, NO_SOURCE_INFO_MSG_EN
+)
 
 logger = logging.getLogger(__name__)
 
@@ -26,28 +33,33 @@ class ResearchReporter:
         source_list_str = "\n".join([f"[{i+1}] {s.title} ({s.link})" for i, s in enumerate(all_sources)])
 
         if not source_list_str:
-            source_info = "No web sources were found."
-            citation_instruction = "Do not use citations."
-        else:
-            source_info = f"Reference Sources:\n{source_list_str}"
             if language == "Japanese":
-                citation_instruction = "番号付きのインライン引用 [1] を使用して出典を明記してください。"
+                source_info = NO_SOURCE_INFO_MSG_JA
+                citation_instruction = NO_CITATION_INSTRUCTION_JA
             else:
-                citation_instruction = "Use numbered in-text citations like [1] to attribute information."
+                source_info = NO_SOURCE_INFO_MSG_EN
+                citation_instruction = NO_CITATION_INSTRUCTION_EN
+        else:
+            if language == "Japanese":
+                source_info = SOURCE_INFO_PROMPT_JA.format(source_list=source_list_str)
+                citation_instruction = CITATION_INSTRUCTION_JA
+            else:
+                source_info = SOURCE_INFO_PROMPT_EN.format(source_list=source_list_str)
+                citation_instruction = CITATION_INSTRUCTION_EN
 
         if language == "Japanese":
-            prompt = (
-                f"トピック: {topic} に関する最終リサーチレポートを作成してください。\n\n"
-                f"コンテキスト:\n{full_context}\n\n"
-                f"{source_info}\n\n"
-                f"指示: 包括的で専門的な構成（日本語）にしてください。{citation_instruction}"
+            prompt = FINAL_REPORT_PROMPT_JA.format(
+                topic=topic,
+                full_context=full_context,
+                source_info=source_info,
+                citation_instruction=citation_instruction
             )
         else:
-            prompt = (
-                f"Synthesize a final report for: {topic}\n\n"
-                f"Context:\n{full_context}\n\n"
-                f"{source_info}\n\n"
-                f"Instruction: Professional structure. {citation_instruction}"
+            prompt = FINAL_REPORT_PROMPT_EN.format(
+                topic=topic,
+                full_context=full_context,
+                source_info=source_info,
+                citation_instruction=citation_instruction
             )
 
         report = await self.llm_client.generate_text(prompt=prompt)

--- a/deep_research_project/core/research_loop.py
+++ b/deep_research_project/core/research_loop.py
@@ -13,6 +13,10 @@ from deep_research_project.core.planning import ResearchPlanner
 from deep_research_project.core.execution import ResearchExecutor
 from deep_research_project.core.reflection import ResearchReflector
 from deep_research_project.core.reporting import ResearchReporter
+from deep_research_project.core.prompts import (
+    NO_INFO_FOUND_MSG_JA, NO_INFO_FOUND_MSG_EN,
+    FOLLOW_UP_PROMPT_JA, FOLLOW_UP_PROMPT_EN
+)
 
 logger = logging.getLogger(__name__)
 
@@ -159,9 +163,9 @@ class ResearchLoop:
         # Handle empty results (from relevance filtering)
         if not selected_results:
             if self.state.language == "Japanese":
-                self.state.new_information = f"クエリ「{self.state.current_query}」に関連する情報が見つかりませんでした。"
+                self.state.new_information = NO_INFO_FOUND_MSG_JA.format(query=self.state.current_query)
             else:
-                self.state.new_information = f"No relevant information found for query: '{self.state.current_query}'"
+                self.state.new_information = NO_INFO_FOUND_MSG_EN.format(query=self.state.current_query)
             
             logger.info(f"No results to summarize for query: '{self.state.current_query}'")
             self.state.pending_source_selection = False
@@ -230,19 +234,9 @@ class ResearchLoop:
     def format_follow_up_prompt(self, final_report: str, question: str) -> str:
         """Formats the prompt for a follow-up question based on the final report."""
         if self.state.language == "Japanese":
-            return (
-                f"以下のリサーチレポートに基づいて、ユーザーのフォローアップ質問に答えてください。\n\n"
-                f"レポート:\n{final_report}\n\n"
-                f"ユーザーの質問: {question}\n\n"
-                f"レポートの内容のみに基づいて、明確で簡潔な回答を提供してください。回答は日本語で行ってください。"
-            )
+            return FOLLOW_UP_PROMPT_JA.format(final_report=final_report, question=question)
         else:
-            return (
-                f"Based on the following research report, answer the user's follow-up question.\n\n"
-                f"Report:\n{final_report}\n\n"
-                f"User Question: {question}\n\n"
-                f"Provide a clear and concise answer based only on the report content."
-            )
+            return FOLLOW_UP_PROMPT_EN.format(final_report=final_report, question=question)
 
     async def _process_section(self, section):
         """Processes a single research section."""


### PR DESCRIPTION
This code health improvement task focused on centralizing all hardcoded LLM prompts and user-facing messages across the core research loop modules. 

Key improvements:
- **Centralization:** All prompts and localized strings are now managed in a single file (`deep_research_project/core/prompts.py`).
- **Consistency:** Ensures that both English and Japanese users receive appropriate messages even in edge cases that were previously hardcoded in a single language.
- **Maintainability:** LLM interaction logic is now separated from string templates, making it easier to update and refine prompts without modifying core logic files.
- **Verification:** All core logic remains intact, and the full test suite passed successfully after the refactor.

---
*PR created automatically by Jules for task [4831556731165627491](https://jules.google.com/task/4831556731165627491) started by @chottokun*