### PR TITLE
Support GPT-5 series models with mandatory temperature override

### DIFF
--- a/deep_research_project/config/config.py
+++ b/deep_research_project/config/config.py
@@ -16,6 +16,7 @@ class Configuration(BaseSettings):
     LLM_MODEL: str = Field(default="default_model_name")
     LLM_TEMPERATURE: float = Field(default=0.7)
     LLM_MAX_TOKENS: int = Field(default=1024)
+    FIXED_TEMPERATURE_MODELS: str = Field(default="gpt-5,o1,o3", description="Comma-separated model name patterns that require fixed temperature (1.0)")
 
     # OpenAI Specific Configuration
     OPENAI_API_KEY: Optional[str] = Field(default=None)
@@ -183,6 +184,7 @@ class Configuration(BaseSettings):
             f"  LLM Model: {self.LLM_MODEL}",
             f"  LLM Temperature: {self.LLM_TEMPERATURE}",
             f"  LLM Max Tokens: {self.LLM_MAX_TOKENS}",
+            f"  Fixed Temperature Models: {self.FIXED_TEMPERATURE_MODELS}",
         ]
         if self.LLM_PROVIDER == "openai" or self.OPENAI_API_BASE_URL: # Show relevant OpenAI details
             config_details.append(f"  OpenAI API Key: {'********' if self.OPENAI_API_KEY else 'Not Set'}")

--- a/deep_research_project/tests/test_gpt5_compatibility.py
+++ b/deep_research_project/tests/test_gpt5_compatibility.py
@@ -14,9 +14,19 @@ class TestGPT5Compatibility(unittest.IsolatedAsyncioTestCase):
         self.mock_config.OPENAI_API_BASE_URL = None
         self.mock_config.LLM_RATE_LIMIT_RPM = 0
         self.mock_config.ENABLE_CACHING = False
+        self.mock_config.FIXED_TEMPERATURE_MODELS = "gpt-5,o1,o3"
 
     async def test_gpt5_temperature_override_init(self):
         self.mock_config.LLM_MODEL = "gpt-5.2"
+        with patch('langchain_openai.ChatOpenAI') as mock_chat:
+            client = LLMClient(self.mock_config)
+            mock_chat.assert_called_once()
+            args, kwargs = mock_chat.call_args
+            self.assertEqual(kwargs['temperature'], 1.0)
+
+    async def test_custom_fixed_temperature_model(self):
+        self.mock_config.LLM_MODEL = "special-reasoning-v1"
+        self.mock_config.FIXED_TEMPERATURE_MODELS = "gpt-5,o1,o3,special-reasoning"
         with patch('langchain_openai.ChatOpenAI') as mock_chat:
             client = LLMClient(self.mock_config)
             mock_chat.assert_called_once()

--- a/deep_research_project/tests/test_gpt5_compatibility.py
+++ b/deep_research_project/tests/test_gpt5_compatibility.py
@@ -1,0 +1,40 @@
+import unittest
+import asyncio
+from unittest.mock import patch, MagicMock, AsyncMock
+from deep_research_project.config.config import Configuration
+from deep_research_project.tools.llm_client import LLMClient
+
+class TestGPT5Compatibility(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.mock_config = MagicMock(spec=Configuration)
+        self.mock_config.LLM_PROVIDER = "openai"
+        self.mock_config.LLM_TEMPERATURE = 0.7
+        self.mock_config.LLM_MAX_TOKENS = 1000
+        self.mock_config.OPENAI_API_KEY = "test"
+        self.mock_config.OPENAI_API_BASE_URL = None
+        self.mock_config.LLM_RATE_LIMIT_RPM = 0
+        self.mock_config.ENABLE_CACHING = False
+
+    async def test_gpt5_temperature_override_init(self):
+        self.mock_config.LLM_MODEL = "gpt-5.2"
+        with patch('langchain_openai.ChatOpenAI') as mock_chat:
+            client = LLMClient(self.mock_config)
+            mock_chat.assert_called_once()
+            args, kwargs = mock_chat.call_args
+            self.assertEqual(kwargs['temperature'], 1.0)
+
+    async def test_gpt5_temperature_override_invoke(self):
+        self.mock_config.LLM_MODEL = "gpt-5-preview"
+        with patch('langchain_openai.ChatOpenAI') as mock_chat:
+            mock_instance = mock_chat.return_value
+            mock_instance.bind.return_value = mock_instance
+            mock_instance.ainvoke = AsyncMock(return_value=MagicMock(content="response"))
+
+            client = LLMClient(self.mock_config)
+            await client.generate_text("test", temperature=0.5)
+
+            # Check if bind was called with temperature=1.0 instead of 0.5
+            mock_instance.bind.assert_called_with(temperature=1.0)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/deep_research_project/tests/test_gpt5_compatibility.py
+++ b/deep_research_project/tests/test_gpt5_compatibility.py
@@ -23,6 +23,14 @@ class TestGPT5Compatibility(unittest.IsolatedAsyncioTestCase):
             args, kwargs = mock_chat.call_args
             self.assertEqual(kwargs['temperature'], 1.0)
 
+    async def test_o1_temperature_override_init(self):
+        self.mock_config.LLM_MODEL = "o1-mini"
+        with patch('langchain_openai.ChatOpenAI') as mock_chat:
+            client = LLMClient(self.mock_config)
+            mock_chat.assert_called_once()
+            args, kwargs = mock_chat.call_args
+            self.assertEqual(kwargs['temperature'], 1.0)
+
     async def test_gpt5_temperature_override_invoke(self):
         self.mock_config.LLM_MODEL = "gpt-5-preview"
         with patch('langchain_openai.ChatOpenAI') as mock_chat:

--- a/deep_research_project/tools/llm_client.py
+++ b/deep_research_project/tools/llm_client.py
@@ -151,12 +151,15 @@ class LLMClient:
         return None # Should not be reached but better than recursion
 
     def _is_fixed_temperature_model(self, model_name: str) -> bool:
-        """Checks if the model belongs to the gpt-5 series or o-series (reasoning models)
-        which may have fixed temperature requirements (typically 1.0)."""
-        if not model_name:
+        """Checks if the model matches any of the patterns defined in the configuration
+        for models requiring a fixed temperature (1.0)."""
+        if not model_name or not hasattr(self.config, "FIXED_TEMPERATURE_MODELS"):
             return False
+
+        patterns = [p.strip().lower() for p in self.config.FIXED_TEMPERATURE_MODELS.split(",") if p.strip()]
         model_name_lower = model_name.lower()
-        return "gpt-5" in model_name_lower or "o1-" in model_name_lower or model_name_lower == "o1" or "o3-" in model_name_lower or model_name_lower == "o3"
+
+        return any(pattern in model_name_lower for pattern in patterns)
 
     async def generate_text(self, prompt: str, temperature: Optional[float] = None) -> str:
         """Asynchronously generates text from a prompt with retry logic and caching."""

--- a/deep_research_project/tools/llm_client.py
+++ b/deep_research_project/tools/llm_client.py
@@ -24,9 +24,15 @@ class LLMClient:
         if self.config.LLM_PROVIDER == "openai":
             try:
                 from langchain_openai import ChatOpenAI
+
+                temperature = self.config.LLM_TEMPERATURE
+                if self._is_gpt5_model(self.config.LLM_MODEL):
+                    logger.info(f"Model {self.config.LLM_MODEL} detected as GPT-5 series. Overriding temperature to 1.0")
+                    temperature = 1.0
+
                 openai_kwargs = {
                     "model_name": self.config.LLM_MODEL,
-                    "temperature": self.config.LLM_TEMPERATURE,
+                    "temperature": temperature,
                     "max_tokens": self.config.LLM_MAX_TOKENS
                 }
                 if self.config.OPENAI_API_KEY:
@@ -144,8 +150,17 @@ class LLMClient:
 
         return None # Should not be reached but better than recursion
 
+    def _is_gpt5_model(self, model_name: str) -> bool:
+        """Checks if the model belongs to the gpt-5 series."""
+        return model_name and "gpt-5" in model_name.lower()
+
     async def generate_text(self, prompt: str, temperature: Optional[float] = None) -> str:
         """Asynchronously generates text from a prompt with retry logic and caching."""
+        if self._is_gpt5_model(self.config.LLM_MODEL):
+            if temperature is not None and temperature != 1.0:
+                logger.info(f"Overriding provided temperature {temperature} to 1.0 for GPT-5 model.")
+            temperature = 1.0
+
         if getattr(self.config, "ENABLE_CACHING", True):
             cached = await self.cache_manager.get_llm_cache(prompt)
             if cached:

--- a/deep_research_project/tools/llm_client.py
+++ b/deep_research_project/tools/llm_client.py
@@ -26,8 +26,8 @@ class LLMClient:
                 from langchain_openai import ChatOpenAI
 
                 temperature = self.config.LLM_TEMPERATURE
-                if self._is_gpt5_model(self.config.LLM_MODEL):
-                    logger.info(f"Model {self.config.LLM_MODEL} detected as GPT-5 series. Overriding temperature to 1.0")
+                if self._is_fixed_temperature_model(self.config.LLM_MODEL):
+                    logger.info(f"Model {self.config.LLM_MODEL} detected as requiring fixed temperature (1.0). Overriding.")
                     temperature = 1.0
 
                 openai_kwargs = {
@@ -150,13 +150,17 @@ class LLMClient:
 
         return None # Should not be reached but better than recursion
 
-    def _is_gpt5_model(self, model_name: str) -> bool:
-        """Checks if the model belongs to the gpt-5 series."""
-        return model_name and "gpt-5" in model_name.lower()
+    def _is_fixed_temperature_model(self, model_name: str) -> bool:
+        """Checks if the model belongs to the gpt-5 series or o-series (reasoning models)
+        which may have fixed temperature requirements (typically 1.0)."""
+        if not model_name:
+            return False
+        model_name_lower = model_name.lower()
+        return "gpt-5" in model_name_lower or "o1-" in model_name_lower or model_name_lower == "o1" or "o3-" in model_name_lower or model_name_lower == "o3"
 
     async def generate_text(self, prompt: str, temperature: Optional[float] = None) -> str:
         """Asynchronously generates text from a prompt with retry logic and caching."""
-        if self._is_gpt5_model(self.config.LLM_MODEL):
+        if self._is_fixed_temperature_model(self.config.LLM_MODEL):
             if temperature is not None and temperature != 1.0:
                 logger.info(f"Overriding provided temperature {temperature} to 1.0 for GPT-5 model.")
             temperature = 1.0


### PR DESCRIPTION
GPT-5 series models (like gpt-5.2) currently only support a temperature setting of 1.0. This change ensures that when such a model is used, the temperature is automatically set to 1.0, regardless of the configuration or runtime parameters, preventing errors during LLM calls.

Key changes:
- Logic in `LLMClient` to detect `gpt-5` in the model name.
- Automatic override of temperature to 1.0 for these models.
- Informative logging when overrides occur.
- New test suite verifying both initialization and runtime behavior.

---
*PR created automatically by Jules for task [133558585776102841](https://jules.google.com/task/133558585776102841) started by @chottokun*