### PR TITLE
LLMポリシーエラーへの対応と回復性の向上

### DIFF
--- a/deep_research_project/core/execution.py
+++ b/deep_research_project/core/execution.py
@@ -79,8 +79,14 @@ class ResearchExecutor:
                     prompt = SUMMARIZE_CHUNK_PROMPT_EN.format(query=query, chunk=chunk)
                 return await self.llm_client.generate_text(prompt=prompt)
 
-        chunk_summaries = await asyncio.gather(*[summarize_chunk(c, u) for c, u in all_chunks_info])
-        valid_summaries = [s for s in chunk_summaries if s]
+        chunk_summaries = await asyncio.gather(*[summarize_chunk(c, u) for c, u in all_chunks_info], return_exceptions=True)
+
+        valid_summaries = []
+        for s in chunk_summaries:
+            if isinstance(s, Exception):
+                logger.error(f"Error summarizing chunk: {s}")
+            elif s:
+                valid_summaries.append(s)
         
         if not valid_summaries:
             return "Failed to generate any summaries from the segments."
@@ -138,8 +144,12 @@ Search Results:{items_text}
             class ScoreBatch(BaseModel):
                 scores: List[float]
             
-            response = await self.llm_client.generate_structured(prompt, ScoreBatch)
-            scores = [max(0.0, min(1.0, s)) for s in response.scores]
+            try:
+                response = await self.llm_client.generate_structured(prompt, ScoreBatch)
+                scores = [max(0.0, min(1.0, s)) for s in response.scores]
+            except Exception as e:
+                logger.warning(f"Structured batch scoring failed: {e}. Falling back to individual scoring.")
+                raise # Let the outer try-except handle the fallback
             
             # Ensure we have the same number of scores as results
             if len(scores) != len(results):

--- a/deep_research_project/tests/test_policy_resilience.py
+++ b/deep_research_project/tests/test_policy_resilience.py
@@ -1,0 +1,53 @@
+import unittest
+import asyncio
+from unittest.mock import MagicMock, AsyncMock, patch
+from deep_research_project.tools.llm_client import LLMClient, LLMPolicyError
+from deep_research_project.config.config import Configuration
+from pydantic import BaseModel
+
+class MockModel(BaseModel):
+    items: list[str]
+
+class TestLLMPolicyResilience(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.mock_config = MagicMock(spec=Configuration)
+        self.mock_config.LLM_PROVIDER = "openai"
+        self.mock_config.LLM_MODEL = "gpt-4"
+        self.mock_config.LLM_TEMPERATURE = 0.7
+        self.mock_config.LLM_MAX_TOKENS = 1000
+        self.mock_config.OPENAI_API_KEY = "test"
+        self.mock_config.OPENAI_API_BASE_URL = None
+        self.mock_config.LLM_RATE_LIMIT_RPM = 0
+        self.mock_config.ENABLE_CACHING = False
+
+        with patch('langchain_openai.ChatOpenAI'):
+            self.client = LLMClient(self.mock_config)
+
+    async def test_generate_text_policy_error(self):
+        # Mock ainvoke to raise a policy error
+        self.client.llm = AsyncMock()
+        self.client.llm.ainvoke.side_effect = Exception("This request was blocked by our content management system / safety policy.")
+
+        # Should return empty string instead of raising
+        res = await self.client.generate_text("Dangerous prompt")
+        self.assertEqual(res, "")
+
+    async def test_generate_structured_policy_error(self):
+        # Mock structured LLM to raise policy error
+        mock_structured_llm = AsyncMock()
+        mock_structured_llm.ainvoke.side_effect = Exception("Policy violation detected.")
+
+        self.client.llm = MagicMock()
+        self.client.llm.with_structured_output.return_value = mock_structured_llm
+
+        # Mock generate_text to also return empty for fallback
+        # In reality LLMClient.generate_text will be called by fallback
+        with patch.object(self.client, 'generate_text', AsyncMock(return_value="")):
+             res = await self.client.generate_structured("Give me JSON", MockModel)
+
+        # Should return a minimal valid model (with empty list)
+        self.assertIsInstance(res, MockModel)
+        self.assertEqual(res.items, [])
+
+if __name__ == '__main__':
+    unittest.main()

--- a/deep_research_project/tools/llm_client.py
+++ b/deep_research_project/tools/llm_client.py
@@ -11,6 +11,10 @@ logger = logging.getLogger(__name__)
 
 T = TypeVar("T", bound=BaseModel)
 
+class LLMPolicyError(Exception):
+    """Exception raised when the LLM provider refuses to process a request due to safety or policy filters."""
+    pass
+
 class LLMClient:
     def __init__(self, config: Configuration):
         self.config = config
@@ -132,6 +136,11 @@ class LLMClient:
             except Exception as e:
                 error_str = str(e).lower()
                 is_rate_limit = "rate limit" in error_str or "429" in error_str
+                is_policy_error = any(kw in error_str for kw in ["policy", "safety", "content_filter", "filtered", "blocked", "management"])
+
+                if is_policy_error:
+                    logger.warning(f"LLM call blocked by policy/safety filter: {e}")
+                    raise LLMPolicyError(f"LLM Policy Violation: {e}")
                 
                 if attempt < max_retries and (is_rate_limit or "timeout" in error_str or "connection" in error_str):
                     delay = base_delay * (2 ** attempt)
@@ -165,7 +174,11 @@ class LLMClient:
                     return response.content
                 return str(response)
 
-            result = await self._invoke_with_retry(_call)
+            try:
+                result = await self._invoke_with_retry(_call)
+            except LLMPolicyError:
+                logger.warning("LLM call suppressed due to policy violation in generate_text. Returning empty string.")
+                return ""
         
         if getattr(self.config, "ENABLE_CACHING", True) and result:
             await self.cache_manager.set_llm_cache(prompt, result)
@@ -197,6 +210,9 @@ class LLMClient:
             try:
                 # Try native structured output with retry
                 result = await self._invoke_with_retry(_call_native)
+            except LLMPolicyError:
+                logger.warning("LLM call suppressed due to policy violation in generate_structured. Falling back to robust extraction.")
+                result = await self._generate_structured_fallback(prompt, response_model)
             except Exception as e:
                 logger.warning(f"Native structured output failed even with retries, falling back to PydanticOutputParser: {e}")
                 result = await self._generate_structured_fallback(prompt, response_model)
@@ -214,7 +230,11 @@ class LLMClient:
         format_instructions = parser.get_format_instructions()
         full_prompt = f"{prompt}\n\n{format_instructions}"
 
-        response_text = await self.generate_text(full_prompt)
+        try:
+            response_text = await self.generate_text(full_prompt)
+        except LLMPolicyError:
+            logger.error("Policy error during structured fallback. Attempting minimal recovery.")
+            return self._robust_json_extract("", response_model)
         
         try:
             # Standard parsing


### PR DESCRIPTION
LLMが「Policy management」やセーフティフィルターなどの理由でリクエストを拒否した際に、リサーチ全体が停止してしまう問題を修正しました。

主な変更点：
1. **LLMClientの強化**: エラーメッセージからポリシー違反（policy, safety, content_filter等）を検知する `LLMPolicyError` を定義しました。
2. **継続性の確保**: `generate_text` ではエラー時に空文字を返し、`generate_structured` では構造化データの最小限の復元を試みるようにしました。これにより、特定の内容がブロックされても他の部分のリサーチを継続できます。
3. **並列処理の堅牢化**: `ResearchExecutor` におけるチャンクごとの要約処理において、一部の失敗が他のチャンクの処理を阻害しないよう `asyncio.gather` のエラーハンドリングを改善しました。
4. **テストの追加**: 模擬的なポリシーエラーを発生させ、期待通りに処理が継続されることを確認するテストを追加しました。

---
*PR created automatically by Jules for task [99043931966981947](https://jules.google.com/task/99043931966981947) started by @chottokun*