### PR TITLE
Add system_prompt support to LLMClient.generate_text

### DIFF
--- a/deep_research_project/core/sub_agents.py
+++ b/deep_research_project/core/sub_agents.py
@@ -36,11 +36,8 @@ class SkillAgent:
             f"Please provide a detailed summary for '{section_title}' based on your expertise."
         )
         
-        full_prompt = f"SYSTEM INSTRUCTIONS:\n{system_prompt}\n\nUSER REQUEST:\n{user_prompt}"
-        
         try:
-            # Fix: current LLMClient.generate_text doesn't support system_prompt arg
-            response = await self.llm_client.generate_text(full_prompt)
+            response = await self.llm_client.generate_text(user_prompt, system_prompt=system_prompt)
             return response
         except Exception as e:
             logger.error(f"Sub-Agent {self.name} failed: {e}")

--- a/deep_research_project/tests/test_sub_agents.py
+++ b/deep_research_project/tests/test_sub_agents.py
@@ -8,7 +8,7 @@ from deep_research_project.config.config import Configuration
 
 class MockLLMClient:
     """A mock LLM client for fast, deterministic unit tests."""
-    async def generate_text(self, prompt: str) -> str:
+    async def generate_text(self, prompt: str, system_prompt: Optional[str] = None) -> str:
         return f"MOCK RESPONSE based on prompt length {len(prompt)}"
 
 @pytest.mark.asyncio

--- a/deep_research_project/tools/llm_client.py
+++ b/deep_research_project/tools/llm_client.py
@@ -5,6 +5,7 @@ import asyncio
 import json
 import re
 from pydantic import BaseModel, ValidationError
+from langchain_core.messages import SystemMessage, HumanMessage
 from deep_research_project.tools.cache_manager import CacheManager
 
 logger = logging.getLogger(__name__)
@@ -175,28 +176,39 @@ class LLMClient:
 
         return any(pattern in model_name_lower for pattern in patterns)
 
-    async def generate_text(self, prompt: str, temperature: Optional[float] = None) -> str:
+    async def generate_text(self, prompt: str, system_prompt: Optional[str] = None, temperature: Optional[float] = None) -> str:
         """Asynchronously generates text from a prompt with retry logic and caching."""
         if self._is_fixed_temperature_model(self.config.LLM_MODEL):
             if temperature is not None and temperature != 1.0:
                 logger.info(f"Overriding provided temperature {temperature} to 1.0 for GPT-5 model.")
             temperature = 1.0
 
+        cache_key = prompt
+        if system_prompt:
+            cache_key = f"SYSTEM: {system_prompt}\nUSER: {prompt}"
+
         if getattr(self.config, "ENABLE_CACHING", True):
-            cached = await self.cache_manager.get_llm_cache(prompt)
+            cached = await self.cache_manager.get_llm_cache(cache_key)
             if cached:
                 logger.info("LLM result retrieved from cache.")
                 return cached
 
         if self.llm == "PlaceholderLLMInstance":
-            result = self._simulate_placeholder(prompt)
+            result = self._simulate_placeholder(prompt, system_prompt=system_prompt)
         else:
             async def _call():
                 llm_to_call = self.llm
                 if temperature is not None and hasattr(self.llm, "bind"):
                     llm_to_call = self.llm.bind(temperature=temperature)
                 
-                response = await llm_to_call.ainvoke(prompt)
+                if system_prompt:
+                    messages = [
+                        SystemMessage(content=system_prompt),
+                        HumanMessage(content=prompt)
+                    ]
+                    response = await llm_to_call.ainvoke(messages)
+                else:
+                    response = await llm_to_call.ainvoke(prompt)
                 
                 # Robustly extract content and handle potential list returns (e.g., from Gemini)
                 content = None
@@ -229,7 +241,7 @@ class LLMClient:
                 return ""
         
         if getattr(self.config, "ENABLE_CACHING", True) and result:
-            await self.cache_manager.set_llm_cache(prompt, result)
+            await self.cache_manager.set_llm_cache(cache_key, result)
         
         return result
 
@@ -363,8 +375,8 @@ class LLMClient:
             # Last resort: try to return a very basic instance
             return response_model.model_validate({})
 
-    def _simulate_placeholder(self, prompt: str) -> str:
-        logger.debug(f"LLMClient (Placeholder) generating text for prompt: '{prompt[:80]}...'")
+    def _simulate_placeholder(self, prompt: str, system_prompt: Optional[str] = None) -> str:
+        logger.debug(f"LLMClient (Placeholder) generating text for prompt: '{prompt[:80]}...' (System prompt present: {system_prompt is not None})")
         if "evaluate if the summary has sufficiently explored" in prompt.lower():
             return "EVALUATION: CONCLUDE\nQUERY: None"
         return f"Simulated LLM response to: {prompt[:50]}..."


### PR DESCRIPTION
Implemented `system_prompt` support in `LLMClient.generate_text`. This allows for better separation of system instructions and user requests, especially for chat-based models. The change includes:
1.  **LLMClient Update**: `generate_text` now accepts an optional `system_prompt`. If provided, it constructs a list of messages (`SystemMessage` and `HumanMessage`) for the underlying LLM call.
2.  **Caching**: The cache key now incorporates the `system_prompt` to ensure unique caching for different system instructions.
3.  **Sub-Agent Update**: `SkillAgent` was updated to pass its instructions as a `system_prompt` instead of manually concatenating them into the user prompt.
4.  **Test Maintenance**: Updated mock implementations in tests to match the new signature.
5.  **Verification**: Verified with a reproduction script and existing unit tests.

---
*PR created automatically by Jules for task [11929333083799349598](https://jules.google.com/task/11929333083799349598) started by @chottokun*