### PR TITLE
🧹 remove unused import os in config.py

### DIFF
--- a/deep_research_project/config/config.py
+++ b/deep_research_project/config/config.py
@@ -1,4 +1,3 @@
-import os
 import logging
 from dotenv import load_dotenv
 from typing import Optional


### PR DESCRIPTION
This change removes the unused `os` module import from `deep_research_project/config/config.py`. This improves code health and reduces clutter without changing the behavior of the application.

---
*PR created automatically by Jules for task [9163150970375360182](https://jules.google.com/task/9163150970375360182) started by @chottokun*