### PR TITLE
🧹 Remove unused import traceback in streamlit_app.py

### DIFF
--- a/deep_research_project/streamlit_app.py
+++ b/deep_research_project/streamlit_app.py
@@ -4,7 +4,6 @@ import os
 import datetime
 import asyncio
 import logging
-import traceback
 import json
 import tempfile
 import html


### PR DESCRIPTION
### 🧹 Remove unused import traceback in streamlit_app.py

#### 🎯 What:
Removed the unused `traceback` import from `deep_research_project/streamlit_app.py`.

#### 💡 Why:
Removing unused imports improves code maintainability by reducing clutter and potential confusion for other developers. It also slightly optimizes the module's load time.

#### ✅ Verification:
- **Syntax Check:** Verified the file still compiles correctly using `python3 -m py_compile deep_research_project/streamlit_app.py`.
- **Reference Check:** Confirmed with `grep` that there are no remaining references to `traceback` in the file.
- **Test Suite:** Ran existing unit tests using `uv run python3 -m unittest discover deep_research_project/tests`. While there are pre-existing failures in the codebase, no new regressions were introduced by this change.

#### ✨ Result:
Improved code health and readability in the Streamlit application entry point.

---
*PR created automatically by Jules for task [6948067590422504285](https://jules.google.com/task/6948067590422504285) started by @chottokun*