### PR TITLE
🧹 cleanup: remove unused import os in scripts/cleanup_domain_skills.py

### DIFF
--- a/scripts/cleanup_domain_skills.py
+++ b/scripts/cleanup_domain_skills.py
@@ -1,4 +1,3 @@
-import os
 import shutil
 from pathlib import Path
 


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was an unused `import os` in `scripts/cleanup_domain_skills.py`.
💡 **Why:** Removing unused imports reduces clutter and improves the maintainability and readability of the codebase.
✅ **Verification:**
- Ran `python3 -m py_compile scripts/cleanup_domain_skills.py` to verify no syntax errors.
- Ran `ruff check scripts/cleanup_domain_skills.py` to ensure no linting issues.
- Manually verified the script functionality by creating a temporary `domain-test` directory and running the script, which successfully deleted it.
✨ **Result:** The code is now cleaner and follows better Python practices by only importing necessary modules.

---
*PR created automatically by Jules for task [182133588173410193](https://jules.google.com/task/182133588173410193) started by @chottokun*