### PR TITLE
🧹 remove unused import and fix async test execution in skills_manager

### DIFF
--- a/deep_research_project/core/skills_manager.py
+++ b/deep_research_project/core/skills_manager.py
@@ -1,4 +1,3 @@
-import os
 import logging
 import asyncio
 from typing import List, Dict, Optional

--- a/deep_research_project/tests/test_skills_manager.py
+++ b/deep_research_project/tests/test_skills_manager.py
@@ -5,13 +5,13 @@ from pathlib import Path
 import os
 from deep_research_project.core.skills_manager import SkillRegistry
 
-class TestSkillRegistry(unittest.TestCase):
-    def setUp(self):
+class TestSkillRegistry(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
         # Create a temporary directory for skills
         self.test_dir = tempfile.mkdtemp()
         self.skills_dir = Path(self.test_dir) / "skills"
 
-    def tearDown(self):
+    async def asyncTearDown(self):
         # Remove the directory after the test
         shutil.rmtree(self.test_dir)
 
@@ -131,7 +131,7 @@ Skill body content
         # Failure case
         self.assertIsNone(registry.get_skill("non_existent"))
 
-    def test_save_skill(self):
+    async def test_save_skill(self):
         # Use another temp dir for static to ensure isolation
         static_dir = Path(self.test_dir) / "static_skills"
         static_dir.mkdir(parents=True, exist_ok=True)
@@ -142,7 +142,7 @@ Skill body content
         desc = "New Description"
         content = "New Content"
 
-        registry.save_skill(skill_id, name, desc, content)
+        await registry.save_skill(skill_id, name, desc, content)
 
         # Verify in memory
         self.assertIn(skill_id, registry.skills)
@@ -155,7 +155,7 @@ Skill body content
         self.assertIn("name: New Skill", file_content)
         self.assertIn("New Content", file_content)
 
-    def test_skill_registry_directories(self):
+    async def test_skill_registry_directories(self):
         """Test that SkillRegistry correctly separates static and dynamic skills."""
         with tempfile.TemporaryDirectory() as static_dir, tempfile.TemporaryDirectory() as dynamic_dir:
             # Create a mock static skill
@@ -183,7 +183,7 @@ Skill body content
             self.assertTrue(registry.skills["dynamic-skill-1"]["is_dynamic"])
 
             # Test save_skill (should save to dynamic dir)
-            registry.save_skill("new-dynamic-skill", "New Skill", "Desc", "Content")
+            await registry.save_skill("new-dynamic-skill", "New Skill", "Desc", "Content")
             
             new_skill_path = Path(dynamic_dir) / "new-dynamic-skill" / "SKILL.md"
             self.assertTrue(new_skill_path.exists(), "New skill must be saved in the dynamic directory")


### PR DESCRIPTION
- 🎯 **What:** Removed an unused `os` import in `skills_manager.py` and refactored its test suite to properly handle asynchronous operations.
- 💡 **Why:** Cleaning up unused imports reduces clutter and improves readability. Fixing the tests ensures that asynchronous methods like `save_skill` are actually executed and verified, preventing silent failures and improving the reliability of the codebase.
- ✅ **Verification:** Ran `uv run python3 -m unittest deep_research_project/tests/test_skills_manager.py` which confirmed that all tests (including the previously failing async tests) now pass successfully.
- ✨ **Result:** A cleaner `skills_manager.py` and a robust, functional test suite that correctly validates asynchronous skill persistence.

---
*PR created automatically by Jules for task [16255538197440099104](https://jules.google.com/task/16255538197440099104) started by @chottokun*