### PR TITLE
🧹 chore: remove unused import SkillRegistry in scripts/test_orchestration.py

### DIFF
--- a/scripts/test_orchestration.py
+++ b/scripts/test_orchestration.py
@@ -4,7 +4,6 @@ import logging
 from deep_research_project.config.config import Configuration
 from deep_research_project.tools.llm_client import LLMClient
 from deep_research_project.core.graph import create_research_graph
-from deep_research_project.core.skills_manager import SkillRegistry
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
This change removes an unused import `SkillRegistry` in `scripts/test_orchestration.py`. This is a code health improvement that reduces clutter and improves maintainability without affecting the script's functionality.

Verification:
- Compiled the script successfully using `uv run python3 -m py_compile`.
- Ran the project test suite; no new regressions were introduced by this change.
- Code review confirmed the change is correct and safe.

---
*PR created automatically by Jules for task [16721618895903601905](https://jules.google.com/task/16721618895903601905) started by @chottokun*