### PR TITLE
🧹 Remove unused import traceback in streamlit_app.py

### DIFF
--- a/deep_research_project/streamlit_app.py
+++ b/deep_research_project/streamlit_app.py
@@ -4,7 +4,6 @@ import os
 import datetime
 import asyncio
 import logging
-import traceback
 import json
 import tempfile
 import html


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Removed the unused `import traceback` from `deep_research_project/streamlit_app.py`.

💡 **Why:** How this improves maintainability
Reducing unused imports makes the code cleaner, improves readability, and avoids potential confusion for future maintainers.

✅ **Verification:** How you confirmed the change is safe
- Verified that `traceback` was not used in the file using `grep`.
- Ran `uv run python3 -m py_compile deep_research_project/streamlit_app.py` to ensure no syntax errors were introduced.
- Ran the full test suite with `uv run pytest` before and after the change; the results were identical (18 failures existed before my change due to unrelated issues), confirming no regressions.
- Received a positive code review.

✨ **Result:** The improvement achieved
A cleaner and slightly more maintainable `streamlit_app.py` file.

---
*PR created automatically by Jules for task [1441470923123599828](https://jules.google.com/task/1441470923123599828) started by @chottokun*