### PR TITLE
🧹 remove unused Callable import

### DIFF
--- a/deep_research_project/streamlit_app.py
+++ b/deep_research_project/streamlit_app.py
@@ -17,7 +17,7 @@ from deep_research_project.core.state import ResearchState
 from deep_research_project.core.research_loop import ResearchLoop
 from streamlit_agraph import agraph, Node, Edge, Config
 from pyvis.network import Network
-from typing import Callable, Optional
+from typing import Optional
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
### 🎯 What
Removed the unused `Callable` import from `deep_research_project/streamlit_app.py`.

### 💡 Why
Removing unused imports reduces clutter and improves code maintainability and readability.

### ✅ Verification
- Verified by running `python3 -m py_compile deep_research_project/streamlit_app.py` to confirm syntax correctness.
- Ran the full test suite using `uv run python3 -m unittest discover deep_research_project/tests/` and confirmed that no new regressions were introduced (baseline failures remained constant).
- Obtained a positive code review.

### ✨ Result
Cleaner and more maintainable code in `deep_research_project/streamlit_app.py`.

---
*PR created automatically by Jules for task [13357982091509474412](https://jules.google.com/task/13357982091509474412) started by @chottokun*