### PR TITLE
🧹 Avoid bare except block in chainlit_app.py

### DIFF
--- a/deep_research_project/chainlit_app.py
+++ b/deep_research_project/chainlit_app.py
@@ -230,8 +230,10 @@ async def run_graph_and_render(graph, input_state, config_dict, config):
                         except json.JSONDecodeError:
                             last_brace = s.rfind('}')
                             if last_brace != -1:
-                                try: return json.loads(s[:last_brace+1])
-                                except: pass
+                                try:
+                                    return json.loads(s[:last_brace+1])
+                                except Exception:
+                                    pass
                             return None
 
                     json_obj = try_repair_json(json_str)


### PR DESCRIPTION
🎯 **What:** Replaced a bare `except:` block with `except Exception:` at line 234 in `deep_research_project/chainlit_app.py`.
💡 **Why:** This is a standard best practice in Python to avoid catching system-level exceptions like `KeyboardInterrupt` or `SystemExit`, which should typically be allowed to propagate.
✅ **Verification:** Verified by inspecting the file content, running a syntax check using `python3 -m py_compile`, and running the project's test suite to ensure no new regressions were introduced.
✨ **Result:** Improved code health and maintainability by following Python error handling best practices.

---
*PR created automatically by Jules for task [14322231089903989123](https://jules.google.com/task/14322231089903989123) started by @chottokun*