### PR TITLE
🧹 [code health improvement] Remove unused SectionPlan import and consolidate prompt imports

### DIFF
--- a/deep_research_project/core/research_loop.py
+++ b/deep_research_project/core/research_loop.py
@@ -3,11 +3,10 @@ import logging
 from typing import List, Dict, Optional, Any, Callable
 
 from deep_research_project.config.config import Configuration
-from deep_research_project.core.state import ResearchState, Source, SearchResult, SectionPlan
+from deep_research_project.core.state import ResearchState, Source, SearchResult
 from deep_research_project.tools.llm_client import LLMClient
 from deep_research_project.tools.search_client import SearchClient
 from deep_research_project.tools.content_retriever import ContentRetriever
-from deep_research_project.core.prompts import FOLLOW_UP_PROMPT_JA, FOLLOW_UP_PROMPT_EN
 
 # New modular components
 from deep_research_project.core.planning import ResearchPlanner


### PR DESCRIPTION
🎯 **What:** Removed unused `SectionPlan` import from `deep_research_project/core/research_loop.py` and consolidated redundant `deep_research_project.core.prompts` imports.
💡 **Why:** Reduces clutter and improves maintainability by removing dead code and redundant imports.
✅ **Verification:** Verified that `SectionPlan` is no longer used in the file and consolidated imports correctly using `grep`. Confirmed that observed test failures (NameError and TypeError) were pre-existing by running tests on the original file.
✨ **Result:** Cleaner and more maintainable import section in `research_loop.py`.

---
*PR created automatically by Jules for task [11213186178011205418](https://jules.google.com/task/11213186178011205418) started by @chottokun*