### PR TITLE
🧹 Remove unused BaseModel import in graph_state.py

### DIFF
--- a/deep_research_project/core/graph_state.py
+++ b/deep_research_project/core/graph_state.py
@@ -1,6 +1,5 @@
 from typing import List, Dict, Optional, TypedDict, Annotated, Any
 import operator
-from pydantic import BaseModel
 from deep_research_project.core.state import SectionPlan, Source
 
 class AgentState(TypedDict):


### PR DESCRIPTION
🎯 **What:** Removed the unused `from pydantic import BaseModel` import from `deep_research_project/core/graph_state.py`.
💡 **Why:** `AgentState` is defined as a `TypedDict`, not a Pydantic `BaseModel`. Removing unused imports improves code cleanliness and maintainability.
✅ **Verification:** Ran `uv run python3 -m unittest deep_research_project/tests/test_deep_graph.py`. While some pre-existing failures were noted in the environment, I verified they persist even when the change is reverted, and my change does not introduce new issues.
✨ **Result:** A cleaner `graph_state.py` file without unnecessary dependencies.

---
*PR created automatically by Jules for task [18202345751449470718](https://jules.google.com/task/18202345751449470718) started by @chottokun*