### PR TITLE
🧹 remove unused typing imports in ki_distiller.py

### DIFF
--- a/deep_research_project/core/ki_distiller.py
+++ b/deep_research_project/core/ki_distiller.py
@@ -2,7 +2,6 @@ import logging
 import json
 import os
 from datetime import datetime
-from typing import Dict, List, Optional
 from deep_research_project.tools.llm_client import LLMClient
 from deep_research_project.core.prompts import (
     KI_METADATA_PROMPT_JA, KI_METADATA_PROMPT_EN


### PR DESCRIPTION
🎯 **What:** Removed unused imports `Dict`, `List`, and `Optional` from `deep_research_project/core/ki_distiller.py`.
💡 **Why:** Removing unused imports reduces code clutter and improves maintainability by ensuring that only necessary dependencies are kept.
✅ **Verification:** 
- Used a custom AST-based script to verify that `Dict`, `List`, and `Optional` are not used as names or in type annotations within the file.
- Confirmed with `grep` that no usages exist outside the import line.
- Verified that the file compiles successfully using `py_compile`.
- Ran the existing test suite (`uv run python3 -m unittest discover deep_research_project/tests`) and confirmed that pre-existing failures are unrelated to this change.
✨ **Result:** Improved code cleanliness in `ki_distiller.py` by removing dead imports.

---
*PR created automatically by Jules for task [17950382808336872434](https://jules.google.com/task/17950382808336872434) started by @chottokun*