### PR TITLE
🧹 Remove unused Dict import from research_loop.py

### DIFF
--- a/deep_research_project/core/research_loop.py
+++ b/deep_research_project/core/research_loop.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from typing import List, Dict, Optional, Any, Callable
+from typing import List, Optional, Any, Callable
 
 from deep_research_project.config.config import Configuration
 from deep_research_project.core.state import ResearchState, Source, SearchResult, SectionPlan


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Removed the unused `Dict` import from the `typing` module in `deep_research_project/core/research_loop.py`.

💡 **Why:** How this improves maintainability
Removing unused imports reduces clutter, improves code readability, and follows Python best practices.

✅ **Verification:** How you confirmed the change is safe
- Verified the syntax of the modified file using `uv run python3 -m py_compile deep_research_project/core/research_loop.py`.
- Confirmed that `Dict` is no longer imported using `grep`.
- Ran relevant tests (`test_research_loop_parallel.py`) and confirmed that pre-existing baseline failures (specifically a `NameError` related to `callback_override`) remained consistent and were not introduced by this change.

✨ **Result:** The improvement achieved
A cleaner import section in `research_loop.py`.

---
*PR created automatically by Jules for task [3154857666376626580](https://jules.google.com/task/3154857666376626580) started by @chottokun*