### PR TITLE
🧪 [unit tests for generate_plan method in planning.py]

### DIFF
--- a/deep_research_project/tests/test_planning.py
+++ b/deep_research_project/tests/test_planning.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, AsyncMock
 from deep_research_project.core.planning import ResearchPlanner
 from deep_research_project.config.config import Configuration
 from deep_research_project.tools.llm_client import LLMClient
+from deep_research_project.core.state import ResearchPlanModel, Section
 
 class TestResearchPlanner(unittest.IsolatedAsyncioTestCase):
     async def asyncSetUp(self):
@@ -50,6 +51,77 @@ class TestResearchPlanner(unittest.IsolatedAsyncioTestCase):
 
         # Should be sanitized (no code fences, only first line)
         self.assertEqual(query, "Code Query")
+
+    async def test_generate_plan_success_en(self):
+        # Setup mock data
+        mock_sections = [
+            Section(title="Section 1", description="Description 1"),
+            Section(title="Section 2", description="Description 2")
+        ]
+        mock_plan = ResearchPlanModel(sections=mock_sections)
+        self.mock_llm.generate_structured = AsyncMock(return_value=mock_plan)
+        self.mock_config.RESEARCH_PLAN_MIN_SECTIONS = 3
+        self.mock_config.RESEARCH_PLAN_MAX_SECTIONS = 5
+
+        progress_callback = AsyncMock()
+
+        topic = "AI Trends"
+        language = "English"
+
+        # Execute
+        plan = await self.planner.generate_plan(topic, language, progress_callback)
+
+        # Verify
+        self.assertEqual(len(plan), 2)
+        self.assertEqual(plan[0]["title"], "Section 1")
+        self.assertEqual(plan[0]["status"], "pending")
+        progress_callback.assert_called_with("Generating structured research plan...")
+
+        # Verify LLM call
+        args, _ = self.mock_llm.generate_structured.call_args
+        prompt = args[0]
+        self.assertIn(topic, prompt)
+        self.assertIn("at least 3", prompt)
+        self.assertIn("at most 5", prompt)
+
+    async def test_generate_plan_success_ja(self):
+        # Setup mock data
+        mock_sections = [
+            Section(title="セクション1", description="説明1")
+        ]
+        mock_plan = ResearchPlanModel(sections=mock_sections)
+        self.mock_llm.generate_structured = AsyncMock(return_value=mock_plan)
+
+        topic = "AIの動向"
+        language = "Japanese"
+
+        # Execute
+        plan = await self.planner.generate_plan(topic, language)
+
+        # Verify
+        self.assertEqual(len(plan), 1)
+        self.assertEqual(plan[0]["title"], "セクション1")
+
+        # Verify LLM call
+        args, _ = self.mock_llm.generate_structured.call_args
+        prompt = args[0]
+        self.assertIn(topic, prompt)
+        self.assertIn("プランは少なくとも", prompt)
+
+    async def test_generate_plan_fallback(self):
+        # Setup mock to raise exception
+        self.mock_llm.generate_structured = AsyncMock(side_effect=Exception("LLM failure"))
+
+        topic = "Failure Topic"
+
+        # Execute
+        plan = await self.planner.generate_plan(topic, "English")
+
+        # Verify fallback plan
+        self.assertEqual(len(plan), 1)
+        self.assertEqual(plan[0]["title"], "General Research")
+        self.assertIn(topic, plan[0]["description"])
+        self.assertEqual(plan[0]["status"], "pending")
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
🎯 **What:** The `generate_plan` method in `deep_research_project/core/planning.py` was previously untested, despite containing critical logic for multi-section research planning and LLM integration.

📊 **Coverage:**
- **Successful Plan Generation (EN/JA):** Verified that the planner correctly formats prompts for English and Japanese, calls the LLM for structured output, and maps the result to the internal `ResearchState` format.
- **Config Integration:** Verified that `RESEARCH_PLAN_MIN_SECTIONS` and `RESEARCH_PLAN_MAX_SECTIONS` are correctly utilized in the LLM prompts.
- **Progress Callbacks:** Ensured that the UI is notified when plan generation starts.
- **Fallback Logic:** Verified that a default research section is returned if the LLM call fails, ensuring robustness.

✨ **Result:** Increased test coverage for the planning module and ensured that the core research orchestration logic is reliable across different languages and failure modes.

---
*PR created automatically by Jules for task [1225367134540686903](https://jules.google.com/task/1225367134540686903) started by @chottokun*