### PR TITLE
🧹 remove unused List import from chainlit_app.py

### DIFF
--- a/deep_research_project/chainlit_app.py
+++ b/deep_research_project/chainlit_app.py
@@ -9,7 +9,7 @@ import logging
 import traceback
 import asyncio
 import aiofiles
-from typing import Dict, Optional, List
+from typing import Dict, Optional
 from pyvis.network import Network
 
 # Ensure imports from parent directory


### PR DESCRIPTION
🎯 **What:** Removed the unused `List` import from `deep_research_project/chainlit_app.py`.
💡 **Why:** Unused imports clutter the code and can lead to confusion. Removing them improves maintainability and follows best practices.
✅ **Verification:** Verified that `List` was not used in the file and that `Dict`/`Optional` were still required. Ran the full test suite (122 tests), all of which passed.
✨ **Result:** Cleaner code in `chainlit_app.py` with no change in functionality.

---
*PR created automatically by Jules for task [4725747471736976035](https://jules.google.com/task/4725747471736976035) started by @chottokun*