### PR TITLE
🧹 Remove unused os import in config.py

### DIFF
--- a/deep_research_project/config/config.py
+++ b/deep_research_project/config/config.py
@@ -1,4 +1,3 @@
-import os
 import logging
 from dotenv import load_dotenv
 from typing import Optional


### PR DESCRIPTION
The `os` module was imported in `deep_research_project/config/config.py` but was not used anywhere in the file. This change removes the unused import to improve code health, maintainability, and readability. I have verified that no regressions were introduced by running the full test suite, which passed successfully.

---
*PR created automatically by Jules for task [190764286622218269](https://jules.google.com/task/190764286622218269) started by @chottokun*