### PR TITLE
🧹 Remove unused import: html in streamlit_app.py

### DIFF
--- a/deep_research_project/streamlit_app.py
+++ b/deep_research_project/streamlit_app.py
@@ -8,7 +8,6 @@ import tempfile
 import logging
 import traceback
 import uuid
-import html
 from typing import Dict, List, Optional, Any
 from pyvis.network import Network
 


### PR DESCRIPTION
I have removed the unused `import html` from `deep_research_project/streamlit_app.py`. This change improves the maintainability and readability of the codebase by removing dead code.

I have verified the change by:
1. Running a syntax check using `python3 -m py_compile`.
2. Running the full project test suite (`uv run python3 -m unittest discover deep_research_project/tests/`), which returned an "OK" result.
3. Confirming that the code still functions as expected, specifically that the use of `st.components.v1.html` (which is a Streamlit-specific function) is not affected by removing the standard library `html` import.
4. Receiving a positive code review for the change.

---
*PR created automatically by Jules for task [7703358004370140678](https://jules.google.com/task/7703358004370140678) started by @chottokun*