### PR TITLE
🧹 Remove unused MemorySaver import from streamlit_app.py

### DIFF
--- a/deep_research_project/streamlit_app.py
+++ b/deep_research_project/streamlit_app.py
@@ -20,7 +20,6 @@ from deep_research_project.core.graph import create_research_graph
 from deep_research_project.tools.llm_client import LLMClient
 from deep_research_project.tools.search_client import SearchClient
 from deep_research_project.tools.content_retriever import ContentRetriever
-from langgraph.checkpoint.memory import MemorySaver
 
 # Logger setup
 logging.basicConfig(level=logging.INFO)


### PR DESCRIPTION
This PR removes an unused import in `deep_research_project/streamlit_app.py`.

🎯 **What:** The `MemorySaver` import from `langgraph.checkpoint.memory` was removed as it was not being used in the file.
💡 **Why:** Removing unused imports reduces technical debt, improves code readability, and minimizes potential confusion for future maintainers.
✅ **Verification:** 
- Grepped the file to ensure no other references to `MemorySaver` existed.
- Ran the full unit test suite (`uv run python3 -m unittest discover deep_research_project/tests/`), which resulted in 122/122 tests passing.
- Streamlit app functionality remains intact as the component was not being utilized.
✨ **Result:** Cleaner and more maintainable codebase.

---
*PR created automatically by Jules for task [14735607314569574271](https://jules.google.com/task/14735607314569574271) started by @chottokun*