### PR TITLE
🧹 Remove unused imports in streamlit_app.py

### DIFF
--- a/deep_research_project/streamlit_app.py
+++ b/deep_research_project/streamlit_app.py
@@ -8,8 +8,6 @@ import tempfile
 import logging
 import traceback
 import uuid
-import html
-from typing import Dict, List, Optional, Any
 from pyvis.network import Network
 
 # Adjust path to import from core
@@ -20,7 +18,6 @@ from deep_research_project.core.graph import create_research_graph
 from deep_research_project.tools.llm_client import LLMClient
 from deep_research_project.tools.search_client import SearchClient
 from deep_research_project.tools.content_retriever import ContentRetriever
-from langgraph.checkpoint.memory import MemorySaver
 
 # Logger setup
 logging.basicConfig(level=logging.INFO)


### PR DESCRIPTION
Removed unused imports in `deep_research_project/streamlit_app.py` to improve code health and maintainability. Specifically, I removed `Any`, `Dict`, `List`, and `Optional` from `typing`, as well as `html` and `MemorySaver`, none of which were utilized in the file. Syntax and regression tests were performed to ensure no functionality was affected.

---
*PR created automatically by Jules for task [15524164352433983178](https://jules.google.com/task/15524164352433983178) started by @chottokun*