### PR TITLE
🧹 Remove unused imports in graph.py

### DIFF
--- a/deep_research_project/core/graph.py
+++ b/deep_research_project/core/graph.py
@@ -1,9 +1,8 @@
 import logging
-import asyncio
 import re
 import json
 from pathlib import Path
-from typing import Dict, List, Any, Optional
+from typing import Any
 from langgraph.graph import StateGraph, END
 from langgraph.checkpoint.memory import MemorySaver
 from deep_research_project.core.graph_state import AgentState


### PR DESCRIPTION
The task was to remove the unused `List` import from `deep_research_project/core/graph.py`. Upon inspection and running `ruff check`, I also found that `asyncio`, `Dict`, and `Optional` were unused in the same file. I removed all of these to further improve code health. I verified the changes by running `ruff check` again and ensuring that the full test suite (122 tests) passed successfully.

---
*PR created automatically by Jules for task [7714251663319027379](https://jules.google.com/task/7714251663319027379) started by @chottokun*