### PR TITLE
🧹 cleanup: remove unused imports from streamlit_app.py

### DIFF
--- a/deep_research_project/streamlit_app.py
+++ b/deep_research_project/streamlit_app.py
@@ -8,8 +8,6 @@ import tempfile
 import logging
 import traceback
 import uuid
-import html
-from typing import Dict, List, Optional, Any
 from pyvis.network import Network
 
 # Adjust path to import from core
@@ -20,7 +18,6 @@ from deep_research_project.core.graph import create_research_graph
 from deep_research_project.tools.llm_client import LLMClient
 from deep_research_project.tools.search_client import SearchClient
 from deep_research_project.tools.content_retriever import ContentRetriever
-from langgraph.checkpoint.memory import MemorySaver
 
 # Logger setup
 logging.basicConfig(level=logging.INFO)


### PR DESCRIPTION
Removed unused imports (`html`, `Dict`, `List`, `Optional`, `Any`, `MemorySaver`) from `deep_research_project/streamlit_app.py`. The cleanup was verified using AST analysis and by running the full test suite to ensure no regressions were introduced.

---
*PR created automatically by Jules for task [12727896875653325760](https://jules.google.com/task/12727896875653325760) started by @chottokun*