### PR TITLE
🧹 Remove unused imports from streamlit_app.py

### DIFF
--- a/deep_research_project/streamlit_app.py
+++ b/deep_research_project/streamlit_app.py
@@ -8,8 +8,6 @@ import tempfile
 import logging
 import traceback
 import uuid
-import html
-from typing import Dict, List, Optional, Any
 from pyvis.network import Network
 
 # Adjust path to import from core
@@ -20,7 +18,6 @@ from deep_research_project.core.graph import create_research_graph
 from deep_research_project.tools.llm_client import LLMClient
 from deep_research_project.tools.search_client import SearchClient
 from deep_research_project.tools.content_retriever import ContentRetriever
-from langgraph.checkpoint.memory import MemorySaver
 
 # Logger setup
 logging.basicConfig(level=logging.INFO)


### PR DESCRIPTION
This PR improves the code health of `deep_research_project/streamlit_app.py` by removing unused imports.

🎯 **What:**
- Removed `Dict`, `List`, `Optional`, and `Any` from `typing`.
- Removed `import html`.
- Removed `from langgraph.checkpoint.memory import MemorySaver`.

💡 **Why:**
Unused imports clutter the codebase, making it harder to read and maintain. Removing them ensures the code only depends on what it actually uses.

✅ **Verification:**
- Ran `grep` to confirm no references to the removed items exist in the file.
- Ran `python3 -m py_compile` to ensure no syntax errors were introduced.
- Ran the full unit test suite (`uv run python3 -m unittest discover deep_research_project/tests/`), which passed 122/122 tests.

✨ **Result:**
A cleaner, more maintainable entry point for the Streamlit application.

---
*PR created automatically by Jules for task [547745863713078239](https://jules.google.com/task/547745863713078239) started by @chottokun*