### PR TITLE
🧹 remove unused Dict import in graph.py

### DIFF
--- a/deep_research_project/core/graph.py
+++ b/deep_research_project/core/graph.py
@@ -3,7 +3,7 @@ import asyncio
 import re
 import json
 from pathlib import Path
-from typing import Dict, List, Any, Optional
+from typing import List, Any, Optional
 from langgraph.graph import StateGraph, END
 from langgraph.checkpoint.memory import MemorySaver
 from deep_research_project.core.graph_state import AgentState


### PR DESCRIPTION
🎯 **What:** Removed the unused `Dict` import from the `typing` module in `deep_research_project/core/graph.py`.
💡 **Why:** Unused imports clutter the codebase and can lead to confusion. Removing them improves maintainability and readability.
✅ **Verification:**
- Confirmed `Dict` is not used in the file via `grep`.
- Ran the full test suite (`uv run python3 -m unittest discover deep_research_project/tests/`), with all 122 tests passing.
- Verified file content after modification.
✨ **Result:** A cleaner `deep_research_project/core/graph.py` file with the unused `Dict` import removed.

---
*PR created automatically by Jules for task [12138137780293034204](https://jules.google.com/task/12138137780293034204) started by @chottokun*