### PR TITLE
🧹 Remove unused imports in streamlit_app.py

### DIFF
--- a/deep_research_project/streamlit_app.py
+++ b/deep_research_project/streamlit_app.py
@@ -8,8 +8,6 @@ import tempfile
 import logging
 import traceback
 import uuid
-import html
-from typing import Dict, List, Optional, Any
 from pyvis.network import Network
 
 # Adjust path to import from core
@@ -20,7 +18,6 @@ from deep_research_project.core.graph import create_research_graph
 from deep_research_project.tools.llm_client import LLMClient
 from deep_research_project.tools.search_client import SearchClient
 from deep_research_project.tools.content_retriever import ContentRetriever
-from langgraph.checkpoint.memory import MemorySaver
 
 # Logger setup
 logging.basicConfig(level=logging.INFO)


### PR DESCRIPTION
This PR addresses a code health issue in `deep_research_project/streamlit_app.py` where several imports were unused. 

Specific changes:
- Removed `import html`.
- Removed `from typing import Dict, List, Optional, Any`.
- Removed `from langgraph.checkpoint.memory import MemorySaver`.

These changes improve the readability and maintainability of the codebase without affecting any functionality. 

Verification:
- Performed a syntax check using `python3 -m py_compile`.
- Ran the full unit test suite (122 tests), all of which passed.
- Verified that the remaining imports are still in use within the file.

---
*PR created automatically by Jules for task [3865922629959590207](https://jules.google.com/task/3865922629959590207) started by @chottokun*