### PR TITLE
🧪 [testing improvement] Add error path tests for score_relevance

### DIFF
--- a/deep_research_project/tests/test_execution.py
+++ b/deep_research_project/tests/test_execution.py
@@ -127,6 +127,30 @@ class TestResearchExecutor(unittest.IsolatedAsyncioTestCase):
         score = await self.executor.score_relevance("query", result, "English")
         self.assertEqual(score, 0.5) # Default
 
+    async def test_score_relevance_attribute_error(self):
+        result = SearchResult(title="T1", link="L1", snippet="S1")
+        # Returning None will cause .strip() to raise AttributeError
+        self.mock_llm_client.generate_text = AsyncMock(return_value=None)
+
+        score = await self.executor.score_relevance("query", result, "English")
+        self.assertEqual(score, 0.5)
+
+    async def test_score_relevance_index_error(self):
+        result = SearchResult(title="T1", link="L1", snippet="S1")
+        # Empty string (after strip) will cause split()[0] to raise IndexError
+        self.mock_llm_client.generate_text = AsyncMock(return_value="   ")
+
+        score = await self.executor.score_relevance("query", result, "English")
+        self.assertEqual(score, 0.5)
+
+    async def test_score_relevance_value_error(self):
+        result = SearchResult(title="T1", link="L1", snippet="S1")
+        # Non-numeric string will cause float() to raise ValueError
+        self.mock_llm_client.generate_text = AsyncMock(return_value="not-a-number")
+
+        score = await self.executor.score_relevance("query", result, "English")
+        self.assertEqual(score, 0.5)
+
     async def test_score_relevance_batch_success(self):
         results = [
             SearchResult(title="T1", link="L1", snippet="S1"),


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was the missing error path tests for the `score_relevance` method in `execution.py`. Specifically, the code had a `try...except (ValueError, IndexError, AttributeError)` block that was not explicitly covered by automated tests.

📊 **Coverage:** The following scenarios are now tested:
- **AttributeError:** Mocked the LLM to return `None`, triggering an `AttributeError` when calling `.strip()` on the response.
- **IndexError:** Mocked the LLM to return a whitespace string, triggering an `IndexError` when attempting to access the first token with `split()[0]`.
- **ValueError:** Mocked the LLM to return a non-numeric string, triggering a `ValueError` during the `float()` conversion.

✨ **Result:** The improvement in test coverage ensures that the `score_relevance` method's robust fallback mechanism (defaulting to 0.5) is verified and protected against future regressions. All 125 tests in the project suite now pass.

---
*PR created automatically by Jules for task [896539327125859466](https://jules.google.com/task/896539327125859466) started by @chottokun*