### PR TITLE
🧹 Remove unused typing import from chainlit_app.py

### DIFF
--- a/deep_research_project/chainlit_app.py
+++ b/deep_research_project/chainlit_app.py
@@ -9,7 +9,7 @@ import logging
 import traceback
 import asyncio
 import aiofiles
-from typing import Dict, Optional, List
+from typing import Dict, Optional
 from pyvis.network import Network
 
 # Ensure imports from parent directory


### PR DESCRIPTION
Removed the unused `List` import from `deep_research_project/chainlit_app.py` while preserving the `Network` import, which was found to be necessary for the knowledge graph generation feature. All tests passed, ensuring no regressions.

---
*PR created automatically by Jules for task [5932582616842956064](https://jules.google.com/task/5932582616842956064) started by @chottokun*