### PR TITLE
🧪 Fix AttributeError and add error-path tests for ResearchReflector

### DIFF
--- a/deep_research_project/core/reflection.py
+++ b/deep_research_project/core/reflection.py
@@ -49,9 +49,9 @@ class ResearchReflector:
             new_id = new_node.id
             if new_id in node_map:
                 existing_node = node_map[new_id]
-                new_props = new_node.properties
+                new_props = new_node.properties or {}
 
-                if 'properties' not in existing_node:
+                if existing_node.get('properties') is None:
                     existing_node['properties'] = new_props.copy()
                 elif new_props:
                     existing_node['properties'].update(new_props)
@@ -89,9 +89,9 @@ class ResearchReflector:
             edge_key = (source, target, label)
             if edge_key in edge_map:
                 existing_edge = edge_map[edge_key]
-                new_props = new_edge.properties
+                new_props = new_edge.properties or {}
 
-                if 'properties' not in existing_edge:
+                if existing_edge.get('properties') is None:
                     existing_edge['properties'] = new_props.copy()
                 elif new_props:
                     existing_edge['properties'].update(new_props)

--- a/deep_research_project/tests/test_reflection_logic.py
+++ b/deep_research_project/tests/test_reflection_logic.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 from deep_research_project.config.config import Configuration
 from deep_research_project.tools.llm_client import LLMClient
 from deep_research_project.core.reflection import ResearchReflector
-from deep_research_project.core.state import KnowledgeGraphModel, KGNode, KGEdge
+from deep_research_project.core.state import KnowledgeGraphModel, KGNode, KGEdge, Source
 
 class TestReflectionLogic(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
@@ -259,6 +259,37 @@ class TestReflectionLogic(unittest.IsolatedAsyncioTestCase):
         self.reflector._merge_knowledge_graph(new_kg, existing_nodes, existing_edges)
         self.assertEqual(existing_nodes[0]["properties"]["p"], "v")
         self.assertEqual(existing_edges[0]["properties"]["ep"], "ev")
+
+    def test_merge_with_none_properties(self):
+        """Test: Handle existing nodes/edges with properties=None"""
+        existing_nodes = [{"id": "Node1", "label": "L", "type": "T", "properties": None, "source_urls": []}]
+        existing_edges = [{"source": "N1", "target": "N2", "label": "R", "properties": None, "source_urls": []}]
+
+        new_kg = KnowledgeGraphModel(
+            nodes=[KGNode(id="Node1", label="L", type="T", properties={"p": "v"}, source_urls=[])],
+            edges=[KGEdge(source="N1", target="N2", label="R", properties={"ep": "ev"}, source_urls=[])]
+        )
+
+        self.reflector._merge_knowledge_graph(new_kg, existing_nodes, existing_edges)
+
+        self.assertEqual(existing_nodes[0]["properties"]["p"], "v")
+        self.assertEqual(existing_nodes[0]["properties"]["mention_count"], "2")
+        self.assertEqual(existing_edges[0]["properties"]["ep"], "ev")
+
+    async def test_extract_knowledge_graph_error_handling(self):
+        """Test: extract_knowledge_graph handles LLM errors gracefully"""
+        self.llm_client.generate_structured.side_effect = Exception("LLM Error")
+
+        existing_nodes = []
+        existing_edges = []
+
+        # Should not raise exception
+        await self.reflector.extract_knowledge_graph(
+            "Some text that is long enough to trigger extraction.",
+            [Source(title="S", link="L")],
+            "Title", "English", existing_nodes, existing_edges
+        )
+        self.assertEqual(len(existing_nodes), 0)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
🎯 **What:** Addressed a potential AttributeError in the knowledge graph merging logic in `reflection.py` where existing nodes or edges could have `properties: None`.

📊 **Coverage:** 
- Added a test case `test_merge_with_none_properties` to verify that the merging logic handles `None` properties by initializing them as empty dictionaries.
- Added `test_extract_knowledge_graph_error_handling` to ensure that LLM failures during extraction are caught and handled gracefully without crashing the loop.

✨ **Result:** Improved the reliability and robustness of the ResearchReflector module, particularly when dealing with malformed or incomplete state data. The test suite now covers these edge cases, increasing the overall coverage to 124 passing tests.

---
*PR created automatically by Jules for task [16100166846764482864](https://jules.google.com/task/16100166846764482864) started by @chottokun*