### PR TITLE
⚡ Optimize Streamlit yielding in progress callbacks

### DIFF
--- a/deep_research_project/streamlit_app.py
+++ b/deep_research_project/streamlit_app.py
@@ -133,7 +133,7 @@ async def run_research_graph(topic: str, config: Configuration, language: str):
                         total = int(match.group(2))
                         p_bar.progress(current / total, text=f"進捗: セクション {current}/{total}")
                 except: pass
-            await asyncio.sleep(0.01) # Yield to Streamlit
+            await asyncio.sleep(0) # Yield to Streamlit
             
         config_dict = {
             "configurable": {
@@ -233,7 +233,7 @@ def main():
                 async def cb(m):
                     st.session_state.logs.append(m)
                     log_container.write(m)
-                    await asyncio.sleep(0.01)
+                    await asyncio.sleep(0)
                     
                 conf = {
                     "configurable": {


### PR DESCRIPTION
### 💡 **What:**
Optimized the `progress_callback` in `deep_research_project/streamlit_app.py` by replacing `await asyncio.sleep(0.01)` with `await asyncio.sleep(0)` at lines 136 and 236.

### 🎯 **Why:**
The previous use of `asyncio.sleep(0.01)` as a hack to yield control in Streamlit loops introduced a mandatory 10ms delay for every log message. This was inefficient and caused unnecessary delays, especially during intensive research loops where many progress updates are generated. Replacing it with `asyncio.sleep(0)` allows the event loop to yield to other tasks (like Streamlit's state management) without a fixed time penalty.

### 📊 **Measured Improvement:**
A benchmark simulating 100 progress update calls showed:
- **Baseline (`sleep(0.01)`):** 1.0258 seconds
- **Optimized (`sleep(0)`):** 0.0010 seconds
- **Improvement:** **99.90% reduction** in yielding overhead.

All 122 existing tests passed, confirming that the change does not break any functionality.

---
*PR created automatically by Jules for task [1740234429513366518](https://jules.google.com/task/1740234429513366518) started by @chottokun*